### PR TITLE
Unhide use statements for a more newb friendly doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ you *expect* might fail, such as lookups by CSS selector.
 Let's start out clicking around on Wikipedia:
 
 ```rust
+use fantoccini::{Client, Locator};
+use futures::future::Future;
 let mut core = tokio_core::reactor::Core::new().unwrap();
 let c = Client::new("http://localhost:4444", &core.handle());
 let c = core.run(c).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@
 //! # extern crate futures;
 //! # extern crate fantoccini;
 //! # fn main() {
-//! # use fantoccini::{Client, Locator};
-//! # use futures::future::Future;
+//! use fantoccini::{Client, Locator};
+//! use futures::future::Future;
 //! let mut core = tokio_core::reactor::Core::new().unwrap();
 //! let c = Client::new("http://localhost:4444", &core.handle());
 //! let c = core.run(c).unwrap();


### PR DESCRIPTION
- Removed `#` from the use statements which unhides statements from generated README.md when you use `cargo readme > README.md`