### PR TITLE
Explicitly mention how to get variable values with execute()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1098,6 +1098,8 @@ impl Client {
     /// `args` is available to the script inside the `arguments` array. Since `Element` implements
     /// `ToJson`, you can also provide serialized `Element`s as arguments, and they will correctly
     /// serialize to DOM elements on the other side.
+    /// 
+    /// To retrieve the value of a variable, `return` has to be used. 
     pub fn execute(
         &self,
         script: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,7 +1099,7 @@ impl Client {
     /// `ToJson`, you can also provide serialized `Element`s as arguments, and they will correctly
     /// serialize to DOM elements on the other side.
     /// 
-    /// To retrieve the value of a variable, `return` has to be used. 
+    /// To retrieve the value of a variable, `return` has to be used in the JavaScript code. 
     pub fn execute(
         &self,
         script: &str,


### PR DESCRIPTION
Explicitly mention that `return` has to be used in the execute method to retrieve the value of a variable.