### PR TITLE
Add default empty first-match capabilities.

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -369,7 +369,7 @@ impl Session {
 
             let session_config = webdriver::capabilities::SpecNewSessionParameters {
                 alwaysMatch: cap.clone(),
-                firstMatch: vec![],
+                firstMatch: vec![webdriver::capabilities::Capabilities::new()],
             };
             let spec = webdriver::command::NewSessionParameters::Spec(session_config);
 


### PR DESCRIPTION
When trying to run `fantoccini` against a local `selenium-server` instance with the main example in the documentation (albeit at http://localhost:4444/wd/hub/ ), I'd see an error of the form: `First match w3c capabilities is zero length`. 

The spec at https://www.w3.org/TR/webdriver1/#processing-capabilities mentions that `firstMatch` capabilities must be non-empty if defined, so this PR makes that happen.