### PR TITLE
Resolve warning about deprecated trait objects without explicit `dyn`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl Error for NewSessionError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             NewSessionError::BadWebdriverUrl(ref e) => Some(e),
             NewSessionError::Failed(ref e) => Some(e),
@@ -149,7 +149,7 @@ impl Error for CmdError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             CmdError::Standard(ref e) | CmdError::NoSuchElement(ref e) => Some(e),
             CmdError::BadUrl(ref e) => Some(e),

--- a/src/session.rs
+++ b/src/session.rs
@@ -96,7 +96,7 @@ enum Ongoing {
     },
     WebDriver {
         ack: Ack,
-        fut: Box<Future<Item = Json, Error = error::CmdError> + Send>,
+        fut: Box<dyn Future<Item = Json, Error = error::CmdError> + Send>,
     },
     Raw {
         ack: Ack,


### PR DESCRIPTION
The compiler produces a
> warning: trait objects without an explicit `dyn` are deprecated

as a result of the `warn(bare_trait_objects)` compiler message being enabled by default.

This commit simply accepts suggested syntax, using `dyn` in these three locations where warnings are produced. I assume these suggestions are what was already being done internally by the compiler.