### PR TITLE
add method for element clear command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1034,8 +1034,7 @@ impl Element {
     pub fn clear(&mut self) -> impl Future<Item = (), Error = error::CmdError> {
         let cmd = WebDriverCommand::ElementClear(self.e.clone());
         self.c.issue(cmd).and_then(move |r| {
-            if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-                // geckodriver returns {} :(
+            if r.is_null() {
                 Ok(())
             } else {
                 Err(error::CmdError::NotW3C(r))
@@ -1429,7 +1428,7 @@ mod tests {
         // go to the Wikipedia frontpage this time
         c.goto("https://www.wikipedia.org/")
             .and_then(|c: Client| {
-                // find, fill out, and submit the search form
+                // find search input element
                 c.wait_for_find(Locator::Id("searchInput"))
             })
             .and_then(|mut e| e.send_keys("foobar").map(|_| e))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,7 +1031,7 @@ impl Element {
     }
 
     /// Clear the contents of this element and then return that element
-    pub fn clear(self) -> impl Future<Item = Element, Error = error::CmdError> {
+    pub fn clear(self) -> impl Future<Item = Client, Error = error::CmdError> {
         let e = self.e;
         let mut c = self.c;
         let cmd = WebDriverCommand::ElementClear(e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1030,6 +1030,21 @@ impl Element {
         })
     }
 
+    /// Clear the contents of this element and then return that element
+    pub fn clear(self) -> impl Future<Item = Element, Error = error::CmdError> {
+        let e = self.e;
+        let mut c = self.c;
+        let cmd = WebDriverCommand::ElementClear(e);
+        c.issue(cmd).and_then(move |r| {
+            if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+                // geckodriver returns {} :(
+                Ok(c)
+            } else {
+                Err(error::CmdError::NotW3C(r))
+            }
+        })
+    }
+
     /// Simulate the user sending keys to an element.
     pub fn send_keys(&mut self, text: &str) -> impl Future<Item = (), Error = error::CmdError> {
         let cmd = WebDriverCommand::ElementSendKeys(

--- a/src/session.rs
+++ b/src/session.rs
@@ -491,6 +491,9 @@ impl Session {
             WebDriverCommand::ElementClick(ref we) => {
                 base.join(&format!("element/{}/click", we.id))
             }
+            WebDriverCommand::ElementClear(ref we) => {
+                base.join(&format!("element/{}/clear", we.id))
+            }
             WebDriverCommand::GetElementText(ref we) => {
                 base.join(&format!("element/{}/text", we.id))
             }
@@ -575,6 +578,7 @@ impl Session {
                 method = Method::POST;
             }
             WebDriverCommand::ElementClick(..)
+            | WebDriverCommand::ElementClear(..)
             | WebDriverCommand::GoBack
             | WebDriverCommand::Refresh => {
                 body = Some("{}".to_string());


### PR DESCRIPTION
Implement the element clear command supported by webdriver
https://docs.rs/webdriver/0.39.0/src/webdriver/command.rs.html#270
https://w3c.github.io/webdriver/#element-clear
Basically renames the element click functionality