### PR TITLE
Convert empty URL strings to "about:blank". Fixes jonhoo/fantoccini#60

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,7 @@ impl Client {
     async fn current_url_(&mut self) -> Result<url::Url, error::CmdError> {
         let url = self.issue(WebDriverCommand::GetCurrentUrl).await?;
         if let Some(url) = url.as_str() {
+            let url = if url.is_empty() { "about:blank" } else { url };
             Ok(url.parse()?)
         } else {
             Err(error::CmdError::NotW3C(url))


### PR DESCRIPTION
This improves Safari compatibility, as `safaridriver` on macOS returns an empty string instead of `about:blank` by default if querying a browser session that is not currently viewing a web page.