### PR TITLE
Improvements to `wait_<…>` functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,13 +692,13 @@ impl Client {
     /// While this currently just spins and yields, it may be more efficient than this in the
     /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
     /// the page.
-    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<&mut Self, error::CmdError>
+    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
     where
         F: FnMut(&mut Client) -> FF,
         FF: Future<Output = Result<bool, error::CmdError>>,
     {
         while !is_ready(self).await? {}
-        Ok(self)
+        Ok(())
     }
 
     /// Wait for the given element to be present on the page.
@@ -732,7 +732,7 @@ impl Client {
     pub async fn wait_for_navigation(
         &mut self,
         current: Option<url::Url>,
-    ) -> Result<&mut Self, error::CmdError> {
+    ) -> Result<(), error::CmdError> {
         let current = match current {
             Some(current) => current,
             None => self.current_url_().await?,
@@ -743,7 +743,9 @@ impl Client {
             let current = current.clone();
             // TODO: and this one too
             let mut c = c.clone();
-            async move { Ok(c.current_url().await? == current) }
+            async move {
+                Ok(c.current_url().await? != current)
+            }
         })
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -743,9 +743,7 @@ impl Client {
             let current = current.clone();
             // TODO: and this one too
             let mut c = c.clone();
-            async move {
-                Ok(c.current_url().await? != current)
-            }
+            async move { Ok(c.current_url().await? != current) }
         })
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,12 +692,12 @@ impl Client {
     /// While this currently just spins and yields, it may be more efficient than this in the
     /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
     /// the page.
-    pub async fn wait_for<F, FF>(mut self, mut is_ready: F) -> Result<Self, error::CmdError>
+    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<&mut Self, error::CmdError>
     where
         F: FnMut(&mut Client) -> FF,
         FF: Future<Output = Result<bool, error::CmdError>>,
     {
-        while !is_ready(&mut self).await? {}
+        while !is_ready(self).await? {}
         Ok(self)
     }
 
@@ -730,9 +730,9 @@ impl Client {
     /// this introduces a race condition: the browser could finish navigating *before* we call
     /// `current_url()`, which would lead to an eternal wait.
     pub async fn wait_for_navigation(
-        mut self,
+        &mut self,
         current: Option<url::Url>,
-    ) -> Result<Self, error::CmdError> {
+    ) -> Result<&mut Self, error::CmdError> {
         let current = match current {
             Some(current) => current,
             None => self.current_url_().await?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ impl Client {
     ///
     /// Calling this method is equivalent to calling `with_raw_client_for` with an empty closure.
     pub async fn raw_client_for(
-        self,
+        &mut self,
         method: Method,
         url: &str,
     ) -> Result<hyper::Response<hyper::Body>, error::CmdError> {
@@ -572,7 +572,7 @@ impl Client {
     /// Before the HTTP request is issued, the given `before` closure will be called with a handle
     /// to the `Request` about to be sent.
     pub async fn with_raw_client_for<F>(
-        mut self,
+        &mut self,
         method: Method,
         url: &str,
         before: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,7 @@ impl Client {
     /// While this currently just spins and yields, it may be more efficient than this in the
     /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
     /// the page.
-    pub async fn wait_for_find(mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+    pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
         let s: webdriver::command::LocatorParameters = search.into();
         loop {
             match self

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -300,16 +300,19 @@ async fn simple_wait_test(mut c: Client) -> Result<(), error::CmdError> {
     c.wait_for(move |_| {
         std::thread::sleep(Duration::from_secs(4));
         async move { Ok(true) }
-    }).await?;
+    })
+    .await?;
 
     c.close().await
 }
 
 async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> {
-    c.goto("https://en.wikipedia.org/").await?;
+    let mut path = std::env::current_dir().unwrap();
+    path.push("tests/redirect_test.html");
 
-    // pulled from https://en.wikipedia.org/wiki/Category:Redirects_to_names_with_title
-    let starting_url = Url::parse("https://en.wikipedia.org/wiki/Michael_Dunlop_Young")?;
+    let path_string = format!("file://{}", path.to_str().unwrap());
+    let file_url_str = path_string.as_str();
+    let starting_url = Url::parse(file_url_str)?;
 
     c.goto(starting_url.as_str()).await?;
 
@@ -319,7 +322,7 @@ async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> 
 
     let final_url = c.current_url().await?;
 
-    assert_eq!(final_url.as_str(), "https://en.wikipedia.org/wiki/Michael_Young,_Baron_Young_of_Dartington");
+    assert_eq!(final_url.as_str(), "https://www.wikipedia.org/");
 
     c.close().await
 }

--- a/tests/redirect_test.html
+++ b/tests/redirect_test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" http-equiv="refresh" content="5;url=https://www.wikipedia.org">
+    <title>This Page will Redirect</title>
+</head>
+<body>
+This page will redirect to https://wikipedia.org
+</body>
+</html>


### PR DESCRIPTION
The `wait_for_find(…)` method on `Client` was taking ownership of the client instance (used `mut self` in the signature instead of a mutable reference to self).

This just changes it to a mutable reference so that calling wait_for_find doesn't move the client.