### PR TITLE
Fix stackoverflow when printing CmdError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -173,8 +173,9 @@ impl Error for CmdError {
 }
 
 impl fmt::Display for CmdError {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: ", self)?;
+        write!(f, "{}: ", self.description())?;
         match *self {
             CmdError::Standard(ref e)
             | CmdError::NoSuchElement(ref e)

--- a/src/error.rs
+++ b/src/error.rs
@@ -230,3 +230,14 @@ impl From<serde_json::Error> for CmdError {
         CmdError::Json(e)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_display_error_doesnt_stackoverflow() {
+        println!("{}", CmdError::NotJson("test".to_string()));
+        println!("{}", NewSessionError::Lost(IOError::last_os_error()));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,8 +43,9 @@ impl Error for NewSessionError {
 }
 
 impl fmt::Display for NewSessionError {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: ", self)?;
+        write!(f, "{}: ", self.description())?;
         match *self {
             NewSessionError::BadWebdriverUrl(ref e) => write!(f, "{}", e),
             NewSessionError::Failed(ref e) => write!(f, "{}", e),


### PR DESCRIPTION
Printing a CmdError currently causes an infinite recursion, calling `<CmdError as Display>::fmt` over and over again until the stack inevitably overflows. This bug was introduced by https://github.com/jonhoo/fantoccini/commit/f05bd488d5dd0391003f61097843365145884730 . We basically undo this commit and add `#[allow(deprecated)]` instead. Those functions aren't going anywhere anyways, we're defining them ourselves!