### PR TITLE
Support the "stale element reference" error from WebDriver

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,7 +72,10 @@ pub enum CmdError {
     /// This variant lifts the ["no such element"] error variant from `Standard` to simplify
     /// checking for it in user code.
     ///
+    /// It is also used for the ["stale element reference"] error variant.
+    ///
     /// ["no such element"]: https://www.w3.org/TR/webdriver/#dfn-no-such-element
+    /// ["stale element reference"]: https://www.w3.org/TR/webdriver/#dfn-stale-element-reference
     NoSuchElement(wderror::WebDriverError),
 
     /// The requested window does not exist.

--- a/src/session.rs
+++ b/src/session.rs
@@ -782,6 +782,7 @@ impl Session {
                             "invalid session id" => ErrorStatus::InvalidSessionId,
                             "no such element" => ErrorStatus::NoSuchElement,
                             "no such window" => ErrorStatus::NoSuchWindow,
+                            "stale element reference" => ErrorStatus::NoSuchElement,
                             _ => unreachable!(
                                 "received unknown error ({}) for NOT_FOUND status code",
                                 error

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -285,7 +285,6 @@ mod chrome {
     }
 
     #[test]
-    #[serial]
     fn stale_element_test() {
         local_tester!(stale_element, "chrome")
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -166,6 +166,21 @@ async fn close_window_twice_errors(mut c: Client) -> Result<(), error::CmdError>
     Ok(())
 }
 
+async fn stale_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let url = sample_page_url(port);
+    c.goto(&url).await?;
+    let elem = c.find(Locator::Css("#other_page_id")).await?;
+
+    // Remove the element from the DOM
+    c.execute("var elem = document.getElementById('other_page_id');
+               elem.parentNode.removeChild(elem);", vec![]).await?;
+
+    match elem.click().await {
+        Err(error::CmdError::NoSuchElement(_)) => Ok(()),
+        _ => panic!("Expected a stale element reference error"),
+    }
+}
+
 mod firefox {
     use super::*;
     #[test]
@@ -215,6 +230,12 @@ mod firefox {
     fn double_close_window_test() {
         tester!(close_window_twice_errors, "firefox")
     }
+
+    #[test]
+    #[serial]
+    fn stale_element_test() {
+        local_tester!(stale_element, "firefox")
+    }
 }
 
 mod chrome {
@@ -257,5 +278,11 @@ mod chrome {
     #[test]
     fn double_close_window_test() {
         tester!(close_window_twice_errors, "chrome")
+    }
+
+    #[test]
+    #[serial]
+    fn stale_element_test() {
+        local_tester!(stale_element, "chrome")
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -172,8 +172,12 @@ async fn stale_element(mut c: Client, port: u16) -> Result<(), error::CmdError> 
     let elem = c.find(Locator::Css("#other_page_id")).await?;
 
     // Remove the element from the DOM
-    c.execute("var elem = document.getElementById('other_page_id');
-               elem.parentNode.removeChild(elem);", vec![]).await?;
+    c.execute(
+        "var elem = document.getElementById('other_page_id');
+         elem.parentNode.removeChild(elem);",
+        vec![],
+    )
+    .await?;
 
     match elem.click().await {
         Err(error::CmdError::NoSuchElement(_)) => Ok(()),


### PR DESCRIPTION
This can happen when a handle on an element is kept but the element is
not on the page anymore (e.g. because it was removed from the DOM or
because the browser navigated to another page).

https://www.w3.org/TR/webdriver/#dfn-stale-element-reference

Note that I reused the existing `NoSuchElement` error variant. Let me know if you would prefer a new `StaleElementReference` error variant instead.