### PR TITLE
Create wait structure

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use hyper::error as herror;
 use std::error::Error;
 use std::fmt;
 use std::io::Error as IOError;
+use std::time::Duration;
 use url::ParseError;
 use webdriver::error as wderror;
 
@@ -120,6 +121,10 @@ pub enum CmdError {
 
     /// Could not decode a base64 image
     ImageDecodeError(::base64::DecodeError),
+
+    /// The user specified timeout is reached
+    /// Contains expired duration
+    Timeout(Duration),
 }
 
 impl CmdError {
@@ -158,6 +163,7 @@ impl Error for CmdError {
             CmdError::NotW3C(..) => "webdriver returned non-conforming response",
             CmdError::InvalidArgument(..) => "invalid argument provided",
             CmdError::ImageDecodeError(..) => "error decoding image",
+            CmdError::Timeout(..) => "timeout occured",
         }
     }
 
@@ -171,7 +177,10 @@ impl Error for CmdError {
             CmdError::Lost(ref e) => Some(e),
             CmdError::Json(ref e) => Some(e),
             CmdError::ImageDecodeError(ref e) => Some(e),
-            CmdError::NotJson(_) | CmdError::NotW3C(_) | CmdError::InvalidArgument(..) => None,
+            CmdError::NotJson(_)
+            | CmdError::NotW3C(_)
+            | CmdError::InvalidArgument(..)
+            | CmdError::Timeout(..) => None,
         }
     }
 }
@@ -191,6 +200,7 @@ impl fmt::Display for CmdError {
             CmdError::Json(ref e) => write!(f, "{}", e),
             CmdError::NotW3C(ref e) => write!(f, "{:?}", e),
             CmdError::ImageDecodeError(ref e) => write!(f, "{:?}", e),
+            CmdError::Timeout(timeout) => write!(f, "timeout was exceeded on {} ms", timeout.as_millis()),
             CmdError::InvalidArgument(ref arg, ref msg) => {
                 write!(f, "Invalid argument `{}`: {}", arg, msg)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,9 @@ pub use hyper::Method;
 /// Error types.
 pub mod error;
 
+/// Wait logic
+pub mod wait;
+
 /// The long-running session future we spawn for multiplexing onto a running WebDriver instance.
 mod session;
 use crate::session::{Cmd, Session};
@@ -711,7 +714,7 @@ impl Client {
     /// While this currently just spins and yields, it may be more efficient than this in the
     /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
     /// the page.
-    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
+    pub async fn wait_for<'a, F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
     where
         F: FnMut(&mut Client) -> FF,
         FF: Future<Output = Result<bool, error::CmdError>>,
@@ -727,20 +730,31 @@ impl Client {
     /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
     /// the page.
     pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
-        let s: webdriver::command::LocatorParameters = search.into();
-        loop {
-            match self
-                .by(webdriver::command::LocatorParameters {
-                    using: s.using,
-                    value: s.value.clone(),
-                })
-                .await
-            {
-                Ok(v) => break Ok(v),
-                Err(error::CmdError::NoSuchElement(_)) => {}
-                Err(e) => break Err(e),
+        fn closure(
+            s: Locator<'_>,
+            mut client: Client, // TODO: handle lifetime issues with &mut Client type
+        ) -> impl Future<Output = Option<Result<Element, error::CmdError>>> {
+            let s: webdriver::command::LocatorParameters = s.into();
+            async move {
+                match client
+                    .by(webdriver::command::LocatorParameters {
+                        using: s.using,
+                        value: s.value.clone(),
+                    })
+                    .await
+                {
+                    Ok(v) => Some(Ok(v)),
+                    Err(error::CmdError::NoSuchElement(_)) => None,
+                    Err(e) => Some(Err(e)),
+                }
             }
         }
+
+        const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+        let mut wait = wait::Wait::new(self, DEFAULT_TIMEOUT);
+        wait.until(move |client| closure(search, client.clone()))
+            .await
+            .map_err(|timeout| error::CmdError::Timeout(timeout))?
     }
 
     /// Wait for the page to navigate to a new URL before proceeding.

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,0 +1,70 @@
+/// The module contains a wait primitive
+use crate::Client;
+use std::future::Future;
+use std::time::Duration;
+
+const DEFAULT_POOLING_INTERVAL: Duration = Duration::from_millis(500);
+
+///
+#[derive(Debug)]
+pub struct Wait<'a> {
+    waiter: DefaultWait<&'a mut Client>,
+}
+
+impl<'a> Wait<'a> {
+    ///
+    pub fn new(client: &'a mut Client, timeout: Duration) -> Self {
+        Self {
+            waiter: DefaultWait::new(client, timeout, DEFAULT_POOLING_INTERVAL),
+        }
+    }
+
+    pub(crate) async fn until<F, FF, R>(&mut self, condition: F) -> Result<R, Duration>
+    where
+        F: FnMut(&mut &mut Client) -> FF,
+        FF: Future<Output = Option<R>>,
+    {
+        self.waiter.until(condition).await
+    }
+}
+
+///
+#[derive(Debug)]
+pub(crate) struct DefaultWait<T> {
+    input: T,
+    timeout: Duration,
+    pooling_interval: Duration,
+}
+
+impl<T> DefaultWait<T> {
+    ///
+    pub(crate) fn new(input: T, timeout: Duration, pooling_interval: Duration) -> Self {
+        Self {
+            input,
+            timeout,
+            pooling_interval,
+        }
+    }
+
+    ///
+    pub(crate) async fn until<F, FF, R>(&mut self, mut condition: F) -> Result<R, Duration>
+    where
+        F: FnMut(&mut T) -> FF,
+        FF: Future<Output = Option<R>>,
+    {
+        let now = std::time::Instant::now();
+
+        loop {
+            match condition(&mut self.input).await {
+                Some(result) => return Ok(result),
+                None => (),
+            }
+
+            if now.elapsed() > self.timeout {
+                return Err(now.elapsed() - self.timeout)?;
+            }
+
+            tokio::time::delay_for(self.pooling_interval).await;
+        }
+    }
+}


### PR DESCRIPTION
### Overview

Hello @jonhoo, I've tried to improve `*_wait` methods by creating a `Wait` structure which will allow to create it's own `rules`.

The design is primarily inspired by C# driver.
Here's an example how it's done in C#.

```c#
var wait = new WebDriverWait(driver, 100);
wait.Until(d => d.FindElements(By.Id("processing")).Count == 0);
```  

And here this example with new `Wait` structure. 

```rust
let mut wait = new Wait::new(client, timeout);
wait.until(|d| async { d.FindElement(Locator::Id("processing")).map_or(None, |_| Some(()) });
```

We also could create a set of predefined methods `wait_for_visible`, `wait_for_not_present` etc...

link #27 
link  #85 

### Implementation

Sadly I didn't figure out a way to support closures properly. There's a huge issue with lifetimes therefore in changed [`wait_for_find`](https://github.com/zhiburt/fantoccini/blob/a69c3370b53df95c3235828c30eb3e60e8527098/src/lib.rs#L732-L758) method I created a nested function which takes a cloned Client. That's only because of my incompetence here otherwise it had to be as simple as in example. I've not resolved the issue yet and decided to send the draft with believe that you may know some of pathways  to resolve this an issue :smile: . 
