### PR TITLE
Add active_element method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,16 @@ impl Client {
         }
     }
 
+    /// Get the active element for this session.
+    pub async fn active_element(&mut self) -> Result<Element, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetActiveElement).await?;
+        let e = self.parse_lookup(res)?;
+        Ok(Element {
+            client: self.clone(),
+            element: e,
+        })
+    }
+
     /// Retrieve the currently active URL for this session.
     pub async fn current_url(&mut self) -> Result<url::Url, error::CmdError> {
         self.current_url_().await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,6 +502,13 @@ impl Client {
     }
 
     /// Get the active element for this session.
+    ///
+    /// The "active" element is the `Element` within the DOM that currently has focus. This will
+    /// often be an `<input>` or `<textarea>` element that currently has the text selection, or
+    /// another input element such as a checkbox or radio button. Which elements are focusable
+    /// depends on the platform and browser configuration.
+    ///
+    /// If no element has focus, the result may be the page body or a `NoSuchElement` error.
     pub async fn active_element(&mut self) -> Result<Element, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetActiveElement).await?;
         let e = self.parse_lookup(res)?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -493,6 +493,7 @@ impl Session {
             WebDriverCommand::NewWindow(..) => base.join("window/new"),
             WebDriverCommand::SwitchToWindow(..) => base.join("window"),
             WebDriverCommand::CloseWindow => base.join("window"),
+            WebDriverCommand::GetActiveElement => base.join("element/active"),
             _ => unimplemented!(),
         }
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -35,6 +35,17 @@ async fn find_and_click_link(mut c: Client, port: u16) -> Result<(), error::CmdE
     c.close().await
 }
 
+async fn get_active_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let url = sample_page_url(port);
+    c.goto(&url).await?;
+    c.find(Locator::Css("#select1")).await?.click().await?;
+
+    let mut active = c.active_element().await?;
+    assert_eq!(active.attr("id").await?, Some(String::from("select1")));
+
+    c.close().await
+}
+
 async fn serialize_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
@@ -259,6 +270,12 @@ mod firefox {
 
     #[test]
     #[serial]
+    fn get_active_element_test() {
+        local_tester!(get_active_element, "firefox")
+    }
+
+    #[test]
+    #[serial]
     fn serialize_element_test() {
         local_tester!(serialize_element, "firefox")
     }
@@ -322,6 +339,11 @@ mod chrome {
     #[test]
     fn find_and_click_link_test() {
         local_tester!(find_and_click_link, "chrome")
+    }
+
+    #[test]
+    fn get_active_element_test() {
+        local_tester!(get_active_element, "chrome")
     }
 
     #[test]


### PR DESCRIPTION
Resolves #98 via the WebDriver `GetActiveElement` command.

This method is useful for example when interacting with a site that provides keyboard shortcuts. 