### PR TITLE
Support reconnecting to an existing session

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,15 @@ impl Client {
         Session::with_capabilities(webdriver, cap).await
     }
 
+    /// Create a `Client` associated with an existing WebDriver session on the server at the given
+    /// URL.
+    pub fn from_session_id(
+        webdriver: &str,
+        session_id: &str,
+    ) -> Result<Client, error::NewSessionError> {
+        Session::from_session_id(webdriver, session_id)
+    }
+
     /// Get the session ID assigned by the WebDriver server to this client.
     pub async fn session_id(&mut self) -> Result<Option<String>, error::CmdError> {
         match self.issue(Cmd::GetSessionId).await? {

--- a/src/session.rs
+++ b/src/session.rs
@@ -439,6 +439,41 @@ impl Session {
         }
     }
 
+    pub fn from_session_id(
+        webdriver: &str,
+        session_id: &str,
+    ) -> Result<Client, error::NewSessionError> {
+        // Where is the WebDriver server?
+        let wdb = webdriver.parse::<url::Url>();
+
+        let wdb = wdb.map_err(error::NewSessionError::BadWebdriverUrl)?;
+
+        // We want a tls-enabled client
+        let client =
+            hyper::Client::builder().build::<_, hyper::Body>(hyper_tls::HttpsConnector::new());
+
+        // We're going to need a channel for sending requests to the WebDriver host
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        // Set up our WebDriver session.
+        tokio::spawn(Session {
+            rx,
+            ongoing: Ongoing::None,
+            client,
+            wdb,
+            session: Some(session_id.to_string()),
+            is_legacy: false,
+            ua: None,
+            persist: false,
+        });
+
+        // now that the session is running, let's do the handshake
+        Ok(Client {
+            tx,
+            is_legacy: false,
+        })
+    }
+
     /// Helper for determining what URL endpoint to use for various requests.
     ///
     /// This mapping is essentially that of https://www.w3.org/TR/webdriver/#list-of-endpoints.

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -334,13 +334,13 @@ mod firefox {
     fn double_close_window_test() {
         tester!(close_window_twice_errors, "firefox")
     }
-  
+
     #[test]
     #[serial]
     fn set_by_name_textarea_test() {
         local_tester!(set_by_name_textarea, "firefox")
     }
-  
+
     #[test]
     #[serial]
     fn stale_element_test() {
@@ -405,7 +405,7 @@ mod chrome {
     fn double_close_window_test() {
         tester!(close_window_twice_errors, "chrome")
     }
-  
+
     #[test]
     fn set_by_name_textarea_test() {
         local_tester!(set_by_name_textarea, "chrome")


### PR DESCRIPTION
This is a sketch of a minimal fix for #57 that just copies what `with_capabilities` is doing but without issuing the `NewSession` command.

I've confirmed that this implementation does what I need right now (allows me to have a CLI that doesn't have to log in to a site on every invocation, for example), but it should probably also do things like try to read the value of `is_legacy` off the WebDriver `status` for the session. It also needs tests, etc.