### PR TITLE
Update basic_setup example to use async await syntax

### DIFF
--- a/examples/basic_setup/Cargo.toml
+++ b/examples/basic_setup/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fantoccini = "0.12.0"
+fantoccini = "0.14.0"
 
 [dependencies.tokio]
-version = "0.2.6"
+version = "0.2.22"
 features = ["macros", "time"] # macros is needed for #[tokio::main], time is for needed for delay_for

--- a/examples/basic_setup/Cargo.toml
+++ b/examples/basic_setup/Cargo.toml
@@ -11,4 +11,4 @@ fantoccini = "0.12.0"
 
 [dependencies.tokio]
 version = "0.2.6"
-features = ["macros"] # Needed for #[tokio::main]
+features = ["macros", "time"] # macros is needed for #[tokio::main], time is for needed for delay_for

--- a/examples/basic_setup/Cargo.toml
+++ b/examples/basic_setup/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "0.1"
-futures = "0.1.14"
-fantoccini = "0.11.9"
+fantoccini = "0.12.0"
+
+[dependencies.tokio]
+version = "0.2.6"
+features = ["macros"] # Needed for #[tokio::main]

--- a/examples/basic_setup/src/main.rs
+++ b/examples/basic_setup/src/main.rs
@@ -16,23 +16,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let get_started_button =
         r#"//a[@class="button button-download ph4 mt0 w-100" and @href="/learn/get-started"]"#;
-    let element = client
-        .wait_for_find(Locator::XPath(get_started_button))
-        .await?;
+    let element = client.find(Locator::XPath(get_started_button)).await?;
     element.click().await?;
     delay_for(Duration::from_millis(3000)).await;
 
     let try_without_installing_button =
         r#"//a[@class="button button-secondary" and @href="https://play.rust-lang.org/"]"#;
     let element = client
-        .wait_for_find(Locator::XPath(try_without_installing_button))
+        .find(Locator::XPath(try_without_installing_button))
         .await?;
     element.click().await?;
     delay_for(Duration::from_millis(3000)).await;
 
     let play_rust_lang_run_button = r#"//div[@class="segmented-button"]/button[1]"#;
     let element = client
-        .wait_for_find(Locator::XPath(play_rust_lang_run_button))
+        .find(Locator::XPath(play_rust_lang_run_button))
         .await?;
     element.click().await?;
     delay_for(Duration::from_millis(6000)).await;

--- a/examples/basic_setup/src/main.rs
+++ b/examples/basic_setup/src/main.rs
@@ -1,4 +1,6 @@
 use fantoccini::{Client, Locator};
+use std::time::Duration;
+use tokio::time::delay_for;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -8,6 +10,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("failed to connect to WebDriver");
 
     client.goto("https://www.rust-lang.org/").await?;
+    // delay_for is an artificial delay only used to see the browsers actions and not necessary
+    // in your own code
+    delay_for(Duration::from_millis(3000)).await;
 
     let get_started_button =
         r#"//a[@class="button button-download ph4 mt0 w-100" and @href="/learn/get-started"]"#;
@@ -15,6 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .wait_for_find(Locator::XPath(get_started_button))
         .await?;
     element.click().await?;
+    delay_for(Duration::from_millis(3000)).await;
 
     let try_without_installing_button =
         r#"//a[@class="button button-secondary" and @href="https://play.rust-lang.org/"]"#;
@@ -22,12 +28,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .wait_for_find(Locator::XPath(try_without_installing_button))
         .await?;
     element.click().await?;
+    delay_for(Duration::from_millis(3000)).await;
 
     let play_rust_lang_run_button = r#"//div[@class="segmented-button"]/button[1]"#;
     let element = client
         .wait_for_find(Locator::XPath(play_rust_lang_run_button))
         .await?;
     element.click().await?;
+    delay_for(Duration::from_millis(6000)).await;
 
     Ok(())
 }

--- a/examples/basic_setup/src/main.rs
+++ b/examples/basic_setup/src/main.rs
@@ -1,46 +1,33 @@
-use fantoccini::error::CmdError;
 use fantoccini::{Client, Locator};
-use futures::future::Future;
-use tokio;
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // expects WebDriver instance to be listening at port 4444
-    let client = Client::new("http://localhost:4444");
+    let mut client = Client::new("http://localhost:4444")
+        .await
+        .expect("failed to connect to WebDriver");
+
+    client.goto("https://www.rust-lang.org/").await?;
+
     let get_started_button =
         r#"//a[@class="button button-download ph4 mt0 w-100" and @href="/learn/get-started"]"#;
+    let element = client
+        .wait_for_find(Locator::XPath(get_started_button))
+        .await?;
+    element.click().await?;
+
     let try_without_installing_button =
         r#"//a[@class="button button-secondary" and @href="https://play.rust-lang.org/"]"#;
+    let element = client
+        .wait_for_find(Locator::XPath(try_without_installing_button))
+        .await?;
+    element.click().await?;
+
     let play_rust_lang_run_button = r#"//div[@class="segmented-button"]/button[1]"#;
+    let element = client
+        .wait_for_find(Locator::XPath(play_rust_lang_run_button))
+        .await?;
+    element.click().await?;
 
-    let rust_lang = client
-        .map_err(|error| unimplemented!("failed to connect to WebDriver: {:?}", error))
-        .and_then(|client| client.goto("https://www.rust-lang.org/"))
-        // client_wait is an artificial delay only used to see the browsers actions and not necessary
-        // in your own code
-        .and_then(|client| client_wait(client, 3000))
-        .and_then(move |client| client.wait_for_find(Locator::XPath(get_started_button)))
-        .and_then(|element| element.click())
-        .and_then(|client| client_wait(client, 3000))
-        .and_then(move |client| client.wait_for_find(Locator::XPath(try_without_installing_button)))
-        .and_then(|element| element.click())
-        .and_then(|client| client_wait(client, 3000))
-        .and_then(move |client| {
-            client.wait_for_find(Locator::XPath(play_rust_lang_run_button))
-        })
-        .and_then(|element| element.click())
-        .and_then(|client| client_wait(client, 6000))
-        .map(|_| ())
-        .map_err(|error| panic!("a WebDriver command failed: {:?}", error));
-
-    tokio::run(rust_lang);
-}
-
-// helper function to delay the client
-fn client_wait(client: Client, delay: u64) -> impl Future<Item = Client, Error = CmdError> {
-    use std::time::{Duration, Instant};
-    use tokio::timer::Delay;
-
-    Delay::new(Instant::now() + Duration::from_millis(delay))
-        .and_then(|_| Ok(client))
-        .map_err(|error| panic!("client failed to wait with error: {:?}", error))
+    Ok(())
 }


### PR DESCRIPTION
Update basic_setup example to use async await syntax

Background: Today I tried to figure out how to use fantoccini, and opened basic_setup example first. I was very confused to find old futures syntax. Hopefully after these changes, newcomers will not have this problem.