### PR TITLE
handle shutdown with not created session

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -271,6 +271,12 @@ impl Future for Session {
 
 impl Session {
     fn shutdown(&mut self, ack: Option<Ack>) {
+        // session was not created
+        if self.session.is_none() {
+            self.ongoing = Ongoing::Break;
+            return;
+        }
+
         let url = {
             self.wdb
                 .join(&format!("session/{}", self.session.as_ref().unwrap()))


### PR DESCRIPTION
If `geckodriver` is not started but we create a `Client` it will return error but also `panic`.

```
ERR: "webdriver server did not respond: error trying to connect: tcp connect error: Cannot assign requested address (os error 99)"
thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/fantoccini-0.14.0/src/session.rs:276:46
```

There was a bare testing so it may affect something.

Sorry if the PR is not correct from code perspective (which may be true)