### PR TITLE
Add a select_by_id command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,6 +1133,15 @@ impl Element {
         self.find(Locator::Css(&locator)).await?.click().await
     }
 
+    /// Find and click an `<option>` child element by its id.
+    ///
+    /// This method clicks the first `<option>` element that has an appropriate `id`.
+    /// If the element wasn't found a erorr will be issued.
+    pub async fn select_by_id(mut self, id: &str) -> Result<Client, error::CmdError> {
+        let locator = format!(r#"option[id='{}']"#, id);
+        self.find(Locator::Css(&locator)).await?.click().await
+    }
+
     /// Switches to the frame contained within the element.
     pub async fn enter_frame(self) -> Result<Client, error::CmdError> {
         let Self {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -273,6 +273,29 @@ async fn select_by_index(mut c: Client, port: u16) -> Result<(), error::CmdError
     Ok(())
 }
 
+async fn select_by_id(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let url = sample_page_url(port);
+    c.goto(&url).await?;
+
+    let mut select_element = c.find(Locator::Css("#select3")).await?;
+
+    // Get first display text
+    let initial_text = select_element.prop("value").await?;
+    assert_eq!(Some("Select3-Option1".into()), initial_text);
+
+    // Select second option
+    select_element
+        .clone()
+        .select_by_id("select3-option-2")
+        .await?;
+
+    // Get display text after selection
+    let text_after_selecting = select_element.prop("value").await?;
+    assert_eq!(Some("Select3-Option2".into()), text_after_selecting);
+
+    Ok(())
+}
+
 async fn resolve_execute_async_value(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
@@ -380,6 +403,11 @@ mod firefox {
     }
 
     #[test]
+    fn select_by_id_test() {
+        local_tester!(select_by_id, "firefox")
+    }
+
+    #[test]
     #[serial]
     fn resolve_execute_async_value_test() {
         local_tester!(resolve_execute_async_value, "firefox")
@@ -451,5 +479,10 @@ mod chrome {
     #[test]
     fn select_by_index_test() {
         local_tester!(select_by_index, "chrome")
+    }
+
+    #[test]
+    fn select_by_id_test() {
+        local_tester!(select_by_id, "chrome")
     }
 }

--- a/tests/test_html/sample_page.html
+++ b/tests/test_html/sample_page.html
@@ -81,5 +81,12 @@
             <option>Select2-Option3</option>
         </select>
     </div>
+    <div>
+        <select id="select3">
+            <option id="select3-option-1" selected>Select3-Option1</option>
+            <option id="select3-option-2">Select3-Option2</option>
+            <option id="select3-option-2">Select3-Option3</option>
+        </select>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
As you may see it's considered to be a 4 functions which select element which could provide a high level function like `select` which would expect `by` parameter or something similar.

```rust
element.select(SelectBy::Value("".to_string));
``` 