### PR TITLE
Replace the test warp server with hyper (remove warp as a dependency)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ http = "0.2"
 tokio = { version = "0.2.0", features = [ "full" ] }
 serial_test = "0.5"
 serial_test_derive = "0.5"
-warp = "0.2.2"


### PR DESCRIPTION
As suggested by @jonhoo in https://github.com/jonhoo/fantoccini/issues/114#issuecomment-755096495 to upgrade faster to tokio 1.0 we could remove warp as a dependency.
The warp server gets replaced by a very simple hyper service. As I don't see a reason why test files could be of another type than html, I've hard coded that in. But this could be fixed quite easily if at any point in time that assumption changes.
Or I can edit the pull request to be more "generic" over the file type, but that would probably require another dependency.

I would be happy to hear some feedback, this is my first pull request ever.