### PR TITLE
Upgrade to tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,21 +18,22 @@ categories = ["api-bindings", "development-tools::testing", "web-programming::ht
 license = "MIT/Apache-2.0"
 
 [dependencies]
-webdriver = "0.41.0"
+webdriver = "0.42.0"
 url = "2.0.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 futures-core = "0.3.0"
 futures-util = "0.3.0"
-tokio = { version = "0.2.0", features = [ "sync" ] }
-hyper = { version = "0.13.0", features = [ "stream" ] }
-hyper-tls = "0.4.0"
+tokio = { version = "1", features = [ "sync", "rt" ] }
+hyper = { version = "0.14", features = [ "stream", "client", "http1" ] }
+hyper-tls = "0.5.0"
 cookie = { version = "0.14", features = ["percent-encode"] }
-base64 = "0.12"
+base64 = "0.13"
 mime = "0.3.9"
 http = "0.2"
 
 [dev-dependencies]
-tokio = { version = "0.2.0", features = [ "full" ] }
+tokio = { version = "1", features = [ "full" ] }
+hyper = { version = "0.14", features = [ "server" ] }
 serial_test = "0.5"
 serial_test_derive = "0.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use hyper::error as herror;
+use hyper::Error as HError;
 use std::error::Error;
 use std::fmt;
 use std::io::Error as IOError;
@@ -11,7 +11,7 @@ pub enum NewSessionError {
     /// The given WebDriver URL is invalid.
     BadWebdriverUrl(ParseError),
     /// The WebDriver server could not be reached.
-    Failed(herror::Error),
+    Failed(HError),
     /// The connection to the WebDriver server was lost.
     Lost(IOError),
     /// The server did not give a WebDriver-conforming response.
@@ -93,7 +93,7 @@ pub enum CmdError {
     BadUrl(ParseError),
 
     /// A request to the WebDriver server failed.
-    Failed(herror::Error),
+    Failed(HError),
 
     /// The connection to the WebDriver server was lost.
     Lost(IOError),
@@ -206,8 +206,8 @@ impl From<ParseError> for CmdError {
     }
 }
 
-impl From<herror::Error> for CmdError {
-    fn from(e: herror::Error) -> Self {
+impl From<HError> for CmdError {
+    fn from(e: HError) -> Self {
         CmdError::Failed(e)
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -177,7 +177,8 @@ impl Ongoing {
 pub(crate) struct Session {
     ongoing: Ongoing,
     rx: mpsc::UnboundedReceiver<Task>,
-    client: hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>,
+    client:
+        hyper::client::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>,
     wdb: url::Url,
     session: Option<String>,
     is_legacy: bool,
@@ -338,8 +339,8 @@ impl Session {
         let wdb = wdb.map_err(error::NewSessionError::BadWebdriverUrl)?;
 
         // We want a tls-enabled client
-        let client =
-            hyper::Client::builder().build::<_, hyper::Body>(hyper_tls::HttpsConnector::new());
+        let client = hyper::client::Client::builder()
+            .build::<_, hyper::Body>(hyper_tls::HttpsConnector::new());
 
         // We're going to need a channel for sending requests to the WebDriver host
         let (tx, rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
We still end up with an unused transitive dependency on tokio 0.2
through `webdriver`. Upstream has a pending fix for that in
https://bugzilla.mozilla.org/show_bug.cgi?id=1684226, but this is still
worthwhile to get out the door.

Fixes #114.