### PR TITLE
Bump webdriver and remove server feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["api-bindings", "development-tools::testing", "web-programming::ht
 license = "MIT/Apache-2.0"
 
 [dependencies]
-webdriver = "0.42.0"
+webdriver = { version = "0.43.0", default-features = false }
 url = "2.0.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
`webdriver 0.43` made the server aspects of the code optional
(https://bugzilla.mozilla.org/show_bug.cgi?id=1684226). We take
advantage of that to get rid of `webdriver`'s `warp` dependency which
brought in an old version of tokio.

This change is unfortunately backwards-incompatible because we publicly
expose types from the `webdriver` crate.