### PR TITLE
Remove serial_test_derive dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ http = "0.2"
 tokio = { version = "1", features = [ "full" ] }
 hyper = { version = "0.14", features = [ "server" ] }
 serial_test = "0.5"
-serial_test_derive = "0.5"

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,6 +1,6 @@
 //! Tests that don't make use of external websites.
 #[macro_use]
-extern crate serial_test_derive;
+extern crate serial_test;
 extern crate fantoccini;
 extern crate futures_util;
 

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -1,6 +1,6 @@
 //! Tests that make use of external websites.
 #[macro_use]
-extern crate serial_test_derive;
+extern crate serial_test;
 
 use fantoccini::{error, Client, Locator, Method};
 use futures_util::TryFutureExt;


### PR DESCRIPTION
`serial_test` since [0.3](https://github.com/palfrey/serial_test/releases/tag/v0.3.0) includes `serial_test_derive` and lets you use the macro without needing to directly include `serial_test_derive`