### PR TITLE
Lots of freshening up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["api-bindings", "development-tools::testing", "web-programming::ht
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["rustls-tls"]
+default = ["native-tls"]
+native-tls = ["hyper-tls"]
 rustls-tls = ["hyper-rustls"]
-openssl-tls = ["hyper-tls"]
 
 [dependencies]
 webdriver = { version = "0.43.0", default-features = false }
@@ -42,3 +42,7 @@ http = "0.2"
 tokio = { version = "1", features = [ "full" ] }
 hyper = { version = "0.14", features = [ "server" ] }
 serial_test = "0.5"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ http = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "full" ] }
-hyper = { version = "0.14", features = [ "server" ] }
+hyper = { version = "0.14", features = [ "server", "tcp" ] }
 serial_test = "0.5"
 
 [package.metadata.docs.rs]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,865 @@
+use crate::elements::{Element, Form};
+use crate::session::{Cmd, Session, Task};
+use crate::{error, Locator};
+use hyper::{client::connect, Method};
+use serde_json::Value as Json;
+use std::convert::TryFrom;
+use std::future::Future;
+use tokio::sync::{mpsc, oneshot};
+use webdriver::command::{
+    NewWindowParameters, SwitchToFrameParameters, SwitchToWindowParameters, WebDriverCommand,
+};
+use webdriver::common::{FrameId, ELEMENT_KEY};
+
+/// A WebDriver client tied to a single browser
+/// [session](https://www.w3.org/TR/webdriver1/#sessions).
+///
+/// Use [`ClientBuilder`](crate::ClientBuilder) to create a new session.
+///
+/// Note that most callers should explicitly call `Client::close`, and wait for the returned
+/// future before exiting. Not doing so may result in the WebDriver session not being cleanly
+/// closed, which is particularly important for some drivers, such as geckodriver, where
+/// multiple simulatenous sessions are not supported. If `close` is not explicitly called, a
+/// session close request will be spawned on the given `handle` when the last instance of this
+/// `Client` is dropped.
+#[derive(Clone, Debug)]
+pub struct Client {
+    pub(crate) tx: mpsc::UnboundedSender<Task>,
+    pub(crate) is_legacy: bool,
+}
+
+impl Client {
+    /// Connect to the WebDriver host running the given address.
+    ///
+    /// The provided `connector` is used to establish the connection to the WebDriver host, and
+    /// should generally be one that supports HTTPS, as that is commonly required by WebDriver
+    /// implementations.
+    ///
+    /// Calls `with_capabilities_and_connector` with an empty capabilities list.
+    pub(crate) async fn new_with_connector<C>(
+        webdriver: &str,
+        connector: C,
+    ) -> Result<Self, error::NewSessionError>
+    where
+        C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
+    {
+        Self::with_capabilities_and_connector(
+            webdriver,
+            &webdriver::capabilities::Capabilities::new(),
+            connector,
+        )
+        .await
+    }
+
+    /// Connect to the WebDriver host running the given address.
+    ///
+    /// Prefer using [`ClientBuilder`](crate::ClientBuilder) over calling this method directly.
+    ///
+    /// The given capabilities will be requested in `alwaysMatch` or `desiredCapabilities`
+    /// depending on the protocol version supported by the server.
+    ///
+    /// Returns a future that resolves to a handle for issuing additional WebDriver tasks.
+    pub async fn with_capabilities_and_connector<C>(
+        webdriver: &str,
+        cap: &webdriver::capabilities::Capabilities,
+        connector: C,
+    ) -> Result<Self, error::NewSessionError>
+    where
+        C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
+    {
+        Session::with_capabilities_and_connector(webdriver, cap, connector).await
+    }
+
+    /// Get the unique session ID assigned by the WebDriver server to this client.
+    pub async fn session_id(&mut self) -> Result<Option<String>, error::CmdError> {
+        match self.issue(Cmd::GetSessionId).await? {
+            Json::String(s) => Ok(Some(s)),
+            Json::Null => Ok(None),
+            v => unreachable!("response to GetSessionId was not a string: {:?}", v),
+        }
+    }
+
+    /// Set the User Agent string to use for all subsequent requests.
+    pub async fn set_ua<S: Into<String>>(&mut self, ua: S) -> Result<(), error::CmdError> {
+        self.issue(Cmd::SetUA(ua.into())).await?;
+        Ok(())
+    }
+
+    /// Get the current User Agent string.
+    pub async fn get_ua(&mut self) -> Result<Option<String>, error::CmdError> {
+        match self.issue(Cmd::GetUA).await? {
+            Json::String(s) => Ok(Some(s)),
+            Json::Null => Ok(None),
+            v => unreachable!("response to GetSessionId was not a string: {:?}", v),
+        }
+    }
+
+    /// Terminate the WebDriver session.
+    ///
+    /// Normally, a shutdown of the WebDriver connection will be initiated when the last clone of a
+    /// `Client` is dropped. Specifically, the shutdown request will be issued using the tokio
+    /// `Handle` given when creating this `Client`. This in turn means that any errors will be
+    /// dropped.
+    ///
+    /// This function is safe to call multiple times, but once it has been called on one instance
+    /// of a `Client`, all requests to other instances of that `Client` will fail.
+    ///
+    /// This function may be useful in conjunction with `raw_client_for`, as it allows you to close
+    /// the automated browser window while doing e.g., a large download.
+    pub async fn close(&mut self) -> Result<(), error::CmdError> {
+        self.issue(Cmd::Shutdown).await?;
+        Ok(())
+    }
+
+    /// Mark this client's session as persistent.
+    ///
+    /// After all instances of a `Client` have been dropped, we normally shut down the WebDriver
+    /// session, which also closes the associated browser window or tab. By calling this method,
+    /// the shutdown command will _not_ be sent to this client's session, meaning its window or tab
+    /// will remain open.
+    ///
+    /// Note that an explicit call to [`Client::close`] will still terminate the session.
+    ///
+    /// This function is safe to call multiple times.
+    pub async fn persist(&mut self) -> Result<(), error::CmdError> {
+        self.issue(Cmd::Persist).await?;
+        Ok(())
+    }
+}
+
+// NOTE: new impl block to keep related methods together.
+
+/// [Navigation](https://www.w3.org/TR/webdriver1/#navigation)
+impl Client {
+    /// Navigate directly to the given URL.
+    ///
+    /// See [9.1 Navigate To](https://www.w3.org/TR/webdriver1/#dfn-navigate-to) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Navigate To"))]
+    pub async fn goto(&mut self, url: &str) -> Result<(), error::CmdError> {
+        let url = url.to_owned();
+        let base = self.current_url_().await?;
+        let url = base.join(&url)?;
+        self.issue(WebDriverCommand::Get(webdriver::command::GetParameters {
+            url: url.into_string(),
+        }))
+        .await?;
+        Ok(())
+    }
+
+    /// Retrieve the currently active URL for this session.
+    ///
+    /// See [9.2 Get Current URL](https://www.w3.org/TR/webdriver1/#dfn-get-current-url) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Current URL"))]
+    pub async fn current_url(&mut self) -> Result<url::Url, error::CmdError> {
+        self.current_url_().await
+    }
+
+    pub(crate) async fn current_url_(&mut self) -> Result<url::Url, error::CmdError> {
+        let url = self.issue(WebDriverCommand::GetCurrentUrl).await?;
+        if let Some(url) = url.as_str() {
+            let url = if url.is_empty() { "about:blank" } else { url };
+            Ok(url.parse()?)
+        } else {
+            Err(error::CmdError::NotW3C(url))
+        }
+    }
+
+    /// Go back to the previous page.
+    ///
+    /// See [9.3 Back](https://www.w3.org/TR/webdriver1/#dfn-back) of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Back"))]
+    pub async fn back(&mut self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::GoBack).await?;
+        Ok(())
+    }
+
+    /// Refresh the current previous page.
+    ///
+    /// See [9.5 Refresh](https://www.w3.org/TR/webdriver1/#dfn-refresh) of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Refresh"))]
+    pub async fn refresh(&mut self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::Refresh).await?;
+        Ok(())
+    }
+}
+
+/// [Command Contexts](https://www.w3.org/TR/webdriver1/#command-contexts)
+impl Client {
+    /// Gets the current window handle.
+    ///
+    /// See [10.1 Get Window Handle](https://www.w3.org/TR/webdriver1/#get-window-handle) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Window Handle"))]
+    pub async fn window(&mut self) -> Result<webdriver::common::WebWindow, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetWindowHandle).await?;
+        match res {
+            Json::String(x) => Ok(webdriver::common::WebWindow(x)),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Closes the current window.
+    ///
+    /// Will close the session if no other windows exist.
+    ///
+    /// Closing a window will not switch the client to one of the remaining windows.
+    /// The switching must be done by calling `switch_to_window` using a still live window
+    /// after the current window has been closed.
+    ///
+    /// See [10.2 Close Window](https://www.w3.org/TR/webdriver1/#close-window) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Close Window"))]
+    pub async fn close_window(&mut self) -> Result<(), error::CmdError> {
+        let _res = self.issue(WebDriverCommand::CloseWindow).await?;
+        Ok(())
+    }
+
+    /// Switches to the chosen window.
+    ///
+    /// See [10.3 Switch To Window](https://www.w3.org/TR/webdriver1/#switch-to-window) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Switch To Window"))]
+    pub async fn switch_to_window(
+        &mut self,
+        window: webdriver::common::WebWindow,
+    ) -> Result<(), error::CmdError> {
+        let params = SwitchToWindowParameters { handle: window.0 };
+        let _res = self.issue(WebDriverCommand::SwitchToWindow(params)).await?;
+        Ok(())
+    }
+
+    /// Gets a list of all active windows (and tabs)
+    ///
+    /// See [10.4 Get Window Handles](https://www.w3.org/TR/webdriver1/#get-window-handles) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Window Handles"))]
+    pub async fn windows(&mut self) -> Result<Vec<webdriver::common::WebWindow>, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetWindowHandles).await?;
+        match res {
+            Json::Array(handles) => handles
+                .into_iter()
+                .map(|handle| match handle {
+                    Json::String(x) => Ok(webdriver::common::WebWindow(x)),
+                    v => Err(error::CmdError::NotW3C(v)),
+                })
+                .collect::<Result<Vec<_>, _>>(),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Creates a new window. If `is_tab` is `true`, then a tab will be created instead.
+    ///
+    /// Windows are treated the same as tabs by the WebDriver protocol. The functions `new_window`,
+    /// `switch_to_window`, `close_window`, `window` and `windows` all operate on both tabs and
+    /// windows.
+    ///
+    /// This operation is only in the editor's draft of the next iteration of the WebDriver
+    /// protocol, and may thus not be supported by all WebDriver implementations. For example, if
+    /// you're using `geckodriver`, you will need `geckodriver > 0.24` and `firefox > 66` to use
+    /// this feature.
+    ///
+    /// See [11.5 New Window](https://w3c.github.io/webdriver/#dfn-new-window) of the editor's
+    /// draft standard.
+    #[cfg_attr(docsrs, doc(alias = "New Window"))]
+    pub async fn new_window(
+        &mut self,
+        as_tab: bool,
+    ) -> Result<webdriver::response::NewWindowResponse, error::CmdError> {
+        let type_hint = if as_tab { "tab" } else { "window" }.to_string();
+        let type_hint = Some(type_hint);
+        let params = NewWindowParameters { type_hint };
+        match self.issue(WebDriverCommand::NewWindow(params)).await? {
+            Json::Object(mut obj) => {
+                let handle = match obj
+                    .remove("handle")
+                    .and_then(|x| x.as_str().map(String::from))
+                {
+                    Some(handle) => handle,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let typ = match obj
+                    .remove("type")
+                    .and_then(|x| x.as_str().map(String::from))
+                {
+                    Some(typ) => typ,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                Ok(webdriver::response::NewWindowResponse { handle, typ })
+            }
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Switches to the frame specified at the index.
+    ///
+    /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
+    pub async fn enter_frame(mut self, index: Option<u16>) -> Result<Client, error::CmdError> {
+        let params = SwitchToFrameParameters {
+            id: index.map(FrameId::Short),
+        };
+        self.issue(WebDriverCommand::SwitchToFrame(params)).await?;
+        Ok(self)
+    }
+
+    /// Switches to the parent of the frame the client is currently contained within.
+    ///
+    /// See [10.6 Switch To Parent Frame](https://www.w3.org/TR/webdriver1/#switch-to-parent-frame)
+    /// of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Switch To Parent Frame"))]
+    pub async fn enter_parent_frame(mut self) -> Result<Client, error::CmdError> {
+        self.issue(WebDriverCommand::SwitchToParentFrame).await?;
+        Ok(self)
+    }
+
+    /// Sets the x, y, width, and height properties of the current window.
+    ///
+    /// See [10.7.2 Set Window Rect](https://www.w3.org/TR/webdriver1/#dfn-set-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
+    pub async fn set_window_rect(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
+            x: Some(x as i32),
+            y: Some(y as i32),
+            width: Some(width as i32),
+            height: Some(height as i32),
+        });
+
+        self.issue(cmd).await?;
+        Ok(())
+    }
+
+    /// Gets the x, y, width, and height properties of the current window.
+    ///
+    /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
+    pub async fn get_window_rect(&mut self) -> Result<(u64, u64, u64, u64), error::CmdError> {
+        match self.issue(WebDriverCommand::GetWindowRect).await? {
+            Json::Object(mut obj) => {
+                let x = match obj.remove("x").and_then(|x| x.as_u64()) {
+                    Some(x) => x,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let y = match obj.remove("y").and_then(|y| y.as_u64()) {
+                    Some(y) => y,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let width = match obj.remove("width").and_then(|width| width.as_u64()) {
+                    Some(width) => width,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let height = match obj.remove("height").and_then(|height| height.as_u64()) {
+                    Some(height) => height,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                Ok((x, y, width, height))
+            }
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Sets the x, y, width, and height properties of the current window.
+    ///
+    /// See [10.7.2 Set Window Rect](https://www.w3.org/TR/webdriver1/#dfn-set-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
+    pub async fn set_window_size(
+        &mut self,
+        width: u32,
+        height: u32,
+    ) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
+            x: None,
+            y: None,
+            width: Some(width as i32),
+            height: Some(height as i32),
+        });
+
+        self.issue(cmd).await?;
+        Ok(())
+    }
+
+    /// Gets the width and height of the current window.
+    ///
+    /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
+    pub async fn get_window_size(&mut self) -> Result<(u64, u64), error::CmdError> {
+        let (_, _, width, height) = self.get_window_rect().await?;
+        Ok((width, height))
+    }
+
+    /// Sets the x, y, width, and height properties of the current window.
+    ///
+    /// See [10.7.2 Set Window Rect](https://www.w3.org/TR/webdriver1/#dfn-set-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
+    pub async fn set_window_position(&mut self, x: u32, y: u32) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
+            x: Some(x as i32),
+            y: Some(y as i32),
+            width: None,
+            height: None,
+        });
+
+        self.issue(cmd).await?;
+        Ok(())
+    }
+
+    /// Gets the x and y top-left coordinate of the current window.
+    ///
+    /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
+    pub async fn get_window_position(&mut self) -> Result<(u64, u64), error::CmdError> {
+        let (x, y, _, _) = self.get_window_rect().await?;
+        Ok((x, y))
+    }
+}
+
+/// [Element Retrieval](https://www.w3.org/TR/webdriver1/#element-retrieval)
+impl Client {
+    /// Find an element on the page that matches the given [`Locator`].
+    ///
+    /// See [12.2 Find Element](https://www.w3.org/TR/webdriver1/#find-element) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Find Element"))]
+    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+        self.by(search.into()).await
+    }
+
+    /// Find all elements on the page that match the given [`Locator`].
+    ///
+    /// See [12.3 Find Elements](https://www.w3.org/TR/webdriver1/#find-elements) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Find Elements"))]
+    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
+        let res = self
+            .issue(WebDriverCommand::FindElements(search.into()))
+            .await?;
+        let array = self.parse_lookup_all(res)?;
+        Ok(array
+            .into_iter()
+            .map(move |e| Element {
+                client: self.clone(),
+                element: e,
+            })
+            .collect())
+    }
+
+    /// Get the active element for this session.
+    ///
+    /// The "active" element is the `Element` within the DOM that currently has focus. This will
+    /// often be an `<input>` or `<textarea>` element that currently has the text selection, or
+    /// another input element such as a checkbox or radio button. Which elements are focusable
+    /// depends on the platform and browser configuration.
+    ///
+    /// If no element has focus, the result may be the page body or a `NoSuchElement` error.
+    ///
+    /// See [12.6 Get Active Element](https://www.w3.org/TR/webdriver1/#dfn-get-active-element) of
+    /// the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Active Element"))]
+    pub async fn active_element(&mut self) -> Result<Element, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetActiveElement).await?;
+        let e = self.parse_lookup(res)?;
+        Ok(Element {
+            client: self.clone(),
+            element: e,
+        })
+    }
+
+    /// Locate a form on the page.
+    ///
+    /// Through the returned `Form`, HTML forms can be filled out and submitted.
+    pub async fn form(&mut self, search: Locator<'_>) -> Result<Form, error::CmdError> {
+        let l = search.into();
+        let res = self.issue(WebDriverCommand::FindElement(l)).await?;
+        let f = self.parse_lookup(res)?;
+        Ok(Form {
+            client: self.clone(),
+            form: f,
+        })
+    }
+}
+
+/// [Document Handling](https://www.w3.org/TR/webdriver1/#document-handling)
+impl Client {
+    /// Get the HTML source for the current page.
+    ///
+    /// See [15.1 Get Page Source](https://www.w3.org/TR/webdriver1/#dfn-get-page-source) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Page Source"))]
+    pub async fn source(&mut self) -> Result<String, error::CmdError> {
+        let src = self.issue(WebDriverCommand::GetPageSource).await?;
+        if let Some(src) = src.as_str() {
+            Ok(src.to_string())
+        } else {
+            Err(error::CmdError::NotW3C(src))
+        }
+    }
+
+    /// Execute the given JavaScript `script` in the current browser session.
+    ///
+    /// `args` is available to the script inside the `arguments` array. Since `Element` implements
+    /// `Serialize`, you can also provide serialized `Element`s as arguments, and they will
+    /// correctly deserialize to DOM elements on the other side.
+    ///
+    /// To retrieve the value of a variable, `return` has to be used in the JavaScript code.
+    ///
+    /// See [15.2.1 Execute Script](https://www.w3.org/TR/webdriver1/#dfn-execute-script) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Execute Script"))]
+    pub async fn execute(
+        &mut self,
+        script: &str,
+        mut args: Vec<Json>,
+    ) -> Result<Json, error::CmdError> {
+        self.fixup_elements(&mut args);
+        let cmd = webdriver::command::JavascriptCommandParameters {
+            script: script.to_string(),
+            args: Some(args),
+        };
+
+        self.issue(WebDriverCommand::ExecuteScript(cmd)).await
+    }
+
+    /// Execute the given async JavaScript `script` in the current browser session.
+    ///
+    /// The provided JavaScript has access to `args` through the JavaScript variable `arguments`.
+    /// The `arguments` array also holds an additional element at the end that provides a completion callback
+    /// for the asynchronous code.
+    ///
+    /// Since `Element` implements `Serialize`, you can also provide serialized `Element`s as arguments, and they will
+    /// correctly deserialize to DOM elements on the other side.
+    ///
+    /// # Examples
+    ///
+    /// Call a web API from the browser and retrieve the value asynchronously
+    ///
+    /// ```ignore
+    /// const JS: &'static str = r#"
+    ///     const [date, callback] = arguments;
+    ///
+    ///     fetch(`http://weather.api/${date}/hourly`)
+    ///     // whenever the HTTP Request completes,
+    ///     // send the value back to the Rust context
+    ///     .then(data => {
+    ///         callback(data.json())
+    ///     })
+    /// "#;
+    ///
+    /// let weather = client.execute_async(JS, vec![date]).await?;
+    /// ```
+    ///
+    /// See [15.2.2 Execute Async
+    /// Script](https://www.w3.org/TR/webdriver1/#dfn-execute-async-script) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Execute Async Script"))]
+    pub async fn execute_async(
+        &mut self,
+        script: &str,
+        mut args: Vec<Json>,
+    ) -> Result<Json, error::CmdError> {
+        self.fixup_elements(&mut args);
+        let cmd = webdriver::command::JavascriptCommandParameters {
+            script: script.to_string(),
+            args: Some(args),
+        };
+
+        self.issue(WebDriverCommand::ExecuteAsyncScript(cmd)).await
+    }
+}
+
+/// [Screen Capture](https://www.w3.org/TR/webdriver1/#screen-capture)
+impl Client {
+    /// Get a PNG-encoded screenshot of the current page.
+    ///
+    /// See [19.1 Take Screenshot](https://www.w3.org/TR/webdriver1/#dfn-take-screenshot) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Take Screenshot"))]
+    pub async fn screenshot(&mut self) -> Result<Vec<u8>, error::CmdError> {
+        let src = self.issue(WebDriverCommand::TakeScreenshot).await?;
+        if let Some(src) = src.as_str() {
+            base64::decode(src).map_err(error::CmdError::ImageDecodeError)
+        } else {
+            Err(error::CmdError::NotW3C(src))
+        }
+    }
+}
+
+/// Operations that wait for a change on the page.
+impl Client {
+    /// Wait for the given function to return `true` before proceeding.
+    ///
+    /// This can be useful to wait for something to appear on the page before interacting with it.
+    /// While this currently just spins and yields, it may be more efficient than this in the
+    /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
+    /// the page.
+    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
+    where
+        F: FnMut(&mut Client) -> FF,
+        FF: Future<Output = Result<bool, error::CmdError>>,
+    {
+        while !is_ready(self).await? {}
+        Ok(())
+    }
+
+    /// Wait for the given element to be present on the page.
+    ///
+    /// This can be useful to wait for something to appear on the page before interacting with it.
+    /// While this currently just spins and yields, it may be more efficient than this in the
+    /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
+    /// the page.
+    pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+        let s: webdriver::command::LocatorParameters = search.into();
+        loop {
+            match self
+                .by(webdriver::command::LocatorParameters {
+                    using: s.using,
+                    value: s.value.clone(),
+                })
+                .await
+            {
+                Ok(v) => break Ok(v),
+                Err(error::CmdError::NoSuchElement(_)) => {}
+                Err(e) => break Err(e),
+            }
+        }
+    }
+
+    /// Wait for the page to navigate to a new URL before proceeding.
+    ///
+    /// If the `current` URL is not provided, `self.current_url()` will be used. Note however that
+    /// this introduces a race condition: the browser could finish navigating *before* we call
+    /// `current_url()`, which would lead to an eternal wait.
+    pub async fn wait_for_navigation(
+        &mut self,
+        current: Option<url::Url>,
+    ) -> Result<(), error::CmdError> {
+        let current = match current {
+            Some(current) => current,
+            None => self.current_url_().await?,
+        };
+
+        self.wait_for(move |c| {
+            // TODO: get rid of this clone
+            let current = current.clone();
+            // TODO: and this one too
+            let mut c = c.clone();
+            async move { Ok(c.current_url().await? != current) }
+        })
+        .await
+    }
+}
+
+/// Raw access to the WebDriver instance.
+impl Client {
+    /// Issue an HTTP request to the given `url` with all the same cookies as the current session.
+    ///
+    /// Calling this method is equivalent to calling `with_raw_client_for` with an empty closure.
+    pub async fn raw_client_for(
+        &mut self,
+        method: Method,
+        url: &str,
+    ) -> Result<hyper::Response<hyper::Body>, error::CmdError> {
+        self.with_raw_client_for(method, url, |req| req.body(hyper::Body::empty()).unwrap())
+            .await
+    }
+
+    /// Build and issue an HTTP request to the given `url` with all the same cookies as the current
+    /// session.
+    ///
+    /// Before the HTTP request is issued, the given `before` closure will be called with a handle
+    /// to the `Request` about to be sent.
+    pub async fn with_raw_client_for<F>(
+        &mut self,
+        method: Method,
+        url: &str,
+        before: F,
+    ) -> Result<hyper::Response<hyper::Body>, error::CmdError>
+    where
+        F: FnOnce(http::request::Builder) -> hyper::Request<hyper::Body>,
+    {
+        let url = url.to_owned();
+        // We need to do some trickiness here. GetCookies will only give us the cookies for the
+        // *current* domain, whereas we want the cookies for `url`'s domain. So, we navigate to the
+        // URL in question, fetch its cookies, and then navigate back. *Except* that we can't do
+        // that either (what if `url` is some huge file?). So we *actually* navigate to some weird
+        // url that's unlikely to exist on the target doamin, and which won't resolve into the
+        // actual content, but will still give the same cookies.
+        //
+        // The fact that cookies can have /path and security constraints makes this even more of a
+        // pain. /path in particular is tricky, because you could have a URL like:
+        //
+        //    example.com/download/some_identifier/ignored_filename_just_for_show
+        //
+        // Imagine if a cookie is set with path=/download/some_identifier. How do we get that
+        // cookie without triggering a request for the (large) file? I don't know. Hence: TODO.
+        let old_url = self.current_url_().await?;
+        let url = old_url.clone().join(&url)?;
+        let cookie_url = url.clone().join("/please_give_me_your_cookies")?;
+        self.goto(cookie_url.as_str()).await?;
+
+        // TODO: go back before we return if this call errors:
+        let cookies = self.issue(WebDriverCommand::GetCookies).await?;
+        if !cookies.is_array() {
+            return Err(error::CmdError::NotW3C(cookies));
+        }
+        self.back().await?;
+        let ua = self.get_ua().await?;
+
+        // now add all the cookies
+        let mut all_ok = true;
+        let mut jar = Vec::new();
+        for cookie in cookies.as_array().unwrap() {
+            if !cookie.is_object() {
+                all_ok = false;
+                break;
+            }
+
+            // https://w3c.github.io/webdriver/webdriver-spec.html#cookies
+            let cookie = cookie.as_object().unwrap();
+            if !cookie.contains_key("name") || !cookie.contains_key("value") {
+                all_ok = false;
+                break;
+            }
+
+            if !cookie["name"].is_string() || !cookie["value"].is_string() {
+                all_ok = false;
+                break;
+            }
+
+            // Note that since we're sending these cookies, all that matters is the mapping
+            // from name to value. The other fields only matter when deciding whether to
+            // include a cookie or not, and the driver has already decided that for us
+            // (GetCookies is for a particular URL).
+            jar.push(
+                cookie::Cookie::new(
+                    cookie["name"].as_str().unwrap().to_owned(),
+                    cookie["value"].as_str().unwrap().to_owned(),
+                )
+                .encoded()
+                .to_string(),
+            );
+        }
+
+        if !all_ok {
+            return Err(error::CmdError::NotW3C(cookies));
+        }
+
+        let mut req = hyper::Request::builder();
+        req = req
+            .method(method)
+            .uri(http::Uri::try_from(url.as_str()).unwrap());
+        req = req.header(hyper::header::COOKIE, jar.join("; "));
+        if let Some(s) = ua {
+            req = req.header(hyper::header::USER_AGENT, s);
+        }
+        let req = before(req);
+        let (tx, rx) = oneshot::channel();
+        self.issue(Cmd::Raw { req, rsp: tx }).await?;
+        match rx.await {
+            Ok(Ok(r)) => Ok(r),
+            Ok(Err(e)) => Err(e.into()),
+            Err(e) => unreachable!("Session ended prematurely: {:?}", e),
+        }
+    }
+}
+
+/// Helper methods
+impl Client {
+    async fn by(
+        &mut self,
+        locator: webdriver::command::LocatorParameters,
+    ) -> Result<Element, error::CmdError> {
+        let res = self.issue(WebDriverCommand::FindElement(locator)).await?;
+        let e = self.parse_lookup(res)?;
+        Ok(Element {
+            client: self.clone(),
+            element: e,
+        })
+    }
+
+    /// Extract the `WebElement` from a `FindElement` or `FindElementElement` command.
+    pub(crate) fn parse_lookup(
+        &self,
+        res: Json,
+    ) -> Result<webdriver::common::WebElement, error::CmdError> {
+        let mut res = match res {
+            Json::Object(o) => o,
+            res => return Err(error::CmdError::NotW3C(res)),
+        };
+
+        // legacy protocol uses "ELEMENT" as identifier
+        let key = if self.is_legacy() {
+            "ELEMENT"
+        } else {
+            ELEMENT_KEY
+        };
+
+        if !res.contains_key(key) {
+            return Err(error::CmdError::NotW3C(Json::Object(res)));
+        }
+
+        match res.remove(key) {
+            Some(Json::String(wei)) => {
+                return Ok(webdriver::common::WebElement(wei));
+            }
+            Some(v) => {
+                res.insert(key.to_string(), v);
+            }
+            None => {}
+        }
+
+        Err(error::CmdError::NotW3C(Json::Object(res)))
+    }
+
+    /// Extract `WebElement`s from a `FindElements` or `FindElementElements` command.
+    pub(crate) fn parse_lookup_all(
+        &self,
+        res: Json,
+    ) -> Result<Vec<webdriver::common::WebElement>, error::CmdError> {
+        let res = match res {
+            Json::Array(a) => a,
+            res => return Err(error::CmdError::NotW3C(res)),
+        };
+
+        let mut array = Vec::new();
+        for json in res {
+            let e = self.parse_lookup(json)?;
+            array.push(e);
+        }
+
+        Ok(array)
+    }
+
+    pub(crate) fn fixup_elements(&self, args: &mut [Json]) {
+        if self.is_legacy() {
+            for arg in args {
+                // the serialization of WebElement uses the W3C index,
+                // but legacy implementations need us to use the "ELEMENT" index
+                if let Json::Object(ref mut o) = *arg {
+                    if let Some(wei) = o.remove(ELEMENT_KEY) {
+                        o.insert("ELEMENT".to_string(), wei);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,0 +1,473 @@
+//! Types used to represent particular elements on a page.
+
+use crate::{error, Client, Locator};
+use serde::Serialize;
+use serde_json::Value as Json;
+use webdriver::command::{SendKeysParameters, SwitchToFrameParameters, WebDriverCommand};
+use webdriver::common::FrameId;
+use webdriver::error::WebDriverError;
+
+/// A single DOM element on the current page.
+///
+/// Note that there is a lot of subtlety in how you can interact with an element through WebDriver,
+/// which [the WebDriver standard goes into detail on](https://www.w3.org/TR/webdriver1/#elements).
+/// The same goes for inspecting [element state](https://www.w3.org/TR/webdriver1/#element-state).
+#[derive(Clone, Debug, Serialize)]
+pub struct Element {
+    #[serde(skip_serializing)]
+    pub(crate) client: Client,
+    #[serde(flatten)]
+    pub(crate) element: webdriver::common::WebElement,
+}
+
+/// An HTML form on the current page.
+#[derive(Clone, Debug)]
+pub struct Form {
+    pub(crate) client: Client,
+    pub(crate) form: webdriver::common::WebElement,
+}
+
+impl Element {
+    /// Get back the [`Client`] hosting this `Element`.
+    pub fn client(self) -> Client {
+        self.client
+    }
+}
+
+/// [Command Contexts](https://www.w3.org/TR/webdriver1/#command-contexts)
+impl Element {
+    /// Switches to the frame contained within the element.
+    ///
+    /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
+    pub async fn enter_frame(self) -> Result<Client, error::CmdError> {
+        let Self {
+            mut client,
+            element,
+        } = self;
+        let params = SwitchToFrameParameters {
+            id: Some(FrameId::Element(element)),
+        };
+        client
+            .issue(WebDriverCommand::SwitchToFrame(params))
+            .await?;
+        Ok(client)
+    }
+}
+
+/// [Element Retrieval](https://www.w3.org/TR/webdriver1/#element-retrieval)
+impl Element {
+    /// Find the first descendant element that matches the given [`Locator`].
+    ///
+    /// See [12.4 Find Element From
+    /// Element](https://www.w3.org/TR/webdriver1/#find-element-from-element) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Find Element From Element"))]
+    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+        let res = self
+            .client
+            .issue(WebDriverCommand::FindElementElement(
+                self.element.clone(),
+                search.into(),
+            ))
+            .await?;
+        let e = self.client.parse_lookup(res)?;
+        Ok(Element {
+            client: self.client.clone(),
+            element: e,
+        })
+    }
+
+    /// Find all descendant elements that match the given [`Locator`].
+    ///
+    /// See [12.5 Find Elemente From
+    /// Element](https://www.w3.org/TR/webdriver1/#find-elements-from-element) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Find Elements From Element"))]
+    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
+        let res = self
+            .client
+            .issue(WebDriverCommand::FindElementElements(
+                self.element.clone(),
+                search.into(),
+            ))
+            .await?;
+        let array = self.client.parse_lookup_all(res)?;
+        Ok(array
+            .into_iter()
+            .map(move |e| Element {
+                client: self.client.clone(),
+                element: e,
+            })
+            .collect())
+    }
+}
+
+/// [Element State](https://www.w3.org/TR/webdriver1/#element-state)
+impl Element {
+    /// Look up an [attribute] value for this element by name.
+    ///
+    /// `Ok(None)` is returned if the element does not have the given attribute.
+    ///
+    /// See [13.2 Get Element Attribute](https://www.w3.org/TR/webdriver1/#get-element-attribute)
+    /// of the WebDriver standard.
+    ///
+    /// [attribute]: https://dom.spec.whatwg.org/#concept-attribute
+    #[cfg_attr(docsrs, doc(alias = "Get Element Attribute"))]
+    pub async fn attr(&mut self, attribute: &str) -> Result<Option<String>, error::CmdError> {
+        let cmd =
+            WebDriverCommand::GetElementAttribute(self.element.clone(), attribute.to_string());
+        match self.client.issue(cmd).await? {
+            Json::String(v) => Ok(Some(v)),
+            Json::Null => Ok(None),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Look up a DOM [property] for this element by name.
+    ///
+    /// `Ok(None)` is returned if the element does not have the given property.
+    ///
+    /// See [13.3 Get Element Property](https://www.w3.org/TR/webdriver1/#get-element-property)
+    /// of the WebDriver standard.
+    ///
+    /// [property]: https://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1
+    #[cfg_attr(docsrs, doc(alias = "Get Element Property"))]
+    pub async fn prop(&mut self, prop: &str) -> Result<Option<String>, error::CmdError> {
+        let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());
+        match self.client.issue(cmd).await? {
+            Json::String(v) => Ok(Some(v)),
+            Json::Null => Ok(None),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Retrieve the text contents of this elment.
+    ///
+    /// See [13.5 Get Element Text](https://www.w3.org/TR/webdriver1/#get-element-text)
+    /// of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Element Text"))]
+    pub async fn text(&mut self) -> Result<String, error::CmdError> {
+        let cmd = WebDriverCommand::GetElementText(self.element.clone());
+        match self.client.issue(cmd).await? {
+            Json::String(v) => Ok(v),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Retrieve the HTML contents of this element.
+    ///
+    /// `inner` dictates whether the wrapping node's HTML is excluded or not. For example, take the
+    /// HTML:
+    ///
+    /// ```html
+    /// <div id="foo"><hr /></div>
+    /// ```
+    ///
+    /// With `inner = true`, `<hr />` would be returned. With `inner = false`,
+    /// `<div id="foo"><hr /></div>` would be returned instead.
+    #[cfg_attr(docsrs, doc(alias = "innerHTML"))]
+    #[cfg_attr(docsrs, doc(alias = "outerHTML"))]
+    pub async fn html(&mut self, inner: bool) -> Result<String, error::CmdError> {
+        let prop = if inner { "innerHTML" } else { "outerHTML" };
+        Ok(self.prop(prop).await?.unwrap())
+    }
+}
+
+/// [Element Interaction](https://www.w3.org/TR/webdriver1/#element-interaction)
+impl Element {
+    /// Simulate the user clicking on this element.
+    ///
+    /// Note that since this *may* result in navigation, we give up the handle to the element.
+    ///
+    /// See [14.1 Element Click](https://www.w3.org/TR/webdriver1/#element-click) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Element Click"))]
+    pub async fn click(mut self) -> Result<Client, error::CmdError> {
+        let cmd = WebDriverCommand::ElementClick(self.element);
+        let r = self.client.issue(cmd).await?;
+        if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+            // geckodriver returns {} :(
+            Ok(self.client)
+        } else {
+            Err(error::CmdError::NotW3C(r))
+        }
+    }
+
+    /// Clear this element.
+    ///
+    /// See [14.2 Element Clear](https://www.w3.org/TR/webdriver1/#element-clear) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Element Clear"))]
+    pub async fn clear(&mut self) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::ElementClear(self.element.clone());
+        let r = self.client.issue(cmd).await?;
+        if r.is_null() {
+            Ok(())
+        } else {
+            Err(error::CmdError::NotW3C(r))
+        }
+    }
+
+    /// Simulate the user sending keys to this element.
+    ///
+    /// This operation scrolls into view the form control element and then sends the provided keys
+    /// to the element. In case the element is not keyboard-interactable, an element not
+    /// interactable error is returned.
+    ///
+    /// See [14.3 Element Send Keys](https://www.w3.org/TR/webdriver1/#element-send-keys) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Element Send Keys"))]
+    pub async fn send_keys(&mut self, text: &str) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::ElementSendKeys(
+            self.element.clone(),
+            SendKeysParameters {
+                text: text.to_owned(),
+            },
+        );
+        let r = self.client.issue(cmd).await?;
+        if r.is_null() {
+            Ok(())
+        } else {
+            Err(error::CmdError::NotW3C(r))
+        }
+    }
+}
+
+/// Higher-level operations.
+impl Element {
+    /// Follow the `href` target of the element matching the given CSS selector *without* causing a
+    /// click interaction.
+    ///
+    /// Note that since this *may* result in navigation, we give up the handle to the element.
+    pub async fn follow(mut self) -> Result<Client, error::CmdError> {
+        let cmd = WebDriverCommand::GetElementAttribute(self.element, "href".to_string());
+        let href = self.client.issue(cmd).await?;
+        let href = match href {
+            Json::String(v) => v,
+            Json::Null => {
+                let e = WebDriverError::new(
+                    webdriver::error::ErrorStatus::InvalidArgument,
+                    "cannot follow element without href attribute",
+                );
+                return Err(error::CmdError::Standard(e));
+            }
+            v => return Err(error::CmdError::NotW3C(v)),
+        };
+
+        let url = self.client.current_url_().await?;
+        let href = url.join(&href)?;
+        self.client.goto(href.as_str()).await?;
+        Ok(self.client)
+    }
+
+    /// Find and click an `option` child element by its `value` attribute.
+    pub async fn select_by_value(mut self, value: &str) -> Result<Client, error::CmdError> {
+        let locator = format!("option[value='{}']", value);
+        let locator = webdriver::command::LocatorParameters {
+            using: webdriver::common::LocatorStrategy::CSSSelector,
+            value: locator,
+        };
+
+        let cmd = WebDriverCommand::FindElementElement(self.element, locator);
+        let v = self.client.issue(cmd).await?;
+        Element {
+            element: self.client.parse_lookup(v)?,
+            client: self.client,
+        }
+        .click()
+        .await
+    }
+
+    /// Find and click an `<option>` child element by its index.
+    ///
+    /// This method clicks the first `<option>` element that is an `index`th child
+    /// (`option:nth-of-type(index+1)`). This will be the `index`th `<option>`
+    /// element if the current element is a `<select>`. If you use this method on
+    /// an `Element` that is _not_ a `<select>` (such as on a full `<form>`), it
+    /// may not do what you expect if there are multiple `<select>` elements
+    /// in the form, or if it there are stray `<option>` in the form.
+    ///
+    /// The indexing in this method is 0-based.
+    pub async fn select_by_index(mut self, index: usize) -> Result<Client, error::CmdError> {
+        let locator = format!("option:nth-of-type({})", index + 1);
+
+        self.find(Locator::Css(&locator)).await?.click().await
+    }
+
+    /// Find and click an `<option>` element by its visible text.
+    ///
+    /// The method doesn't make any escaping for the argument like it is done in python webdriver client for [example].
+    /// It also doesn't make any normalizations before match.
+    ///
+    /// [example]: https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/py/selenium/webdriver/support/select.py#L67
+    pub async fn select_by_label(mut self, label: &str) -> Result<Client, error::CmdError> {
+        let locator = format!(r".//option[.='{}']", label);
+        self.find(Locator::XPath(&locator)).await?.click().await
+    }
+}
+
+impl Form {
+    /// Get back the [`Client`] hosting this `Form`.
+    pub fn client(self) -> Client {
+        self.client
+    }
+}
+
+impl Form {
+    /// Find a form input using the given `locator` and set its value to `value`.
+    pub async fn set(
+        &mut self,
+        locator: Locator<'_>,
+        value: &str,
+    ) -> Result<Self, error::CmdError> {
+        let locator = WebDriverCommand::FindElementElement(self.form.clone(), locator.into());
+        let value = Json::from(value);
+
+        let res = self.client.issue(locator).await?;
+        let field = self.client.parse_lookup(res)?;
+        let mut args = vec![via_json!(&field), value];
+        self.client.fixup_elements(&mut args);
+        let cmd = webdriver::command::JavascriptCommandParameters {
+            script: "arguments[0].value = arguments[1]".to_string(),
+            args: Some(args),
+        };
+
+        let res = self
+            .client
+            .issue(WebDriverCommand::ExecuteScript(cmd))
+            .await?;
+        if res.is_null() {
+            Ok(Form {
+                client: self.client.clone(),
+                form: self.form.clone(),
+            })
+        } else {
+            Err(error::CmdError::NotW3C(res))
+        }
+    }
+
+    /// Find a form input with the given `name` and set its value to `value`.
+    pub async fn set_by_name(&mut self, field: &str, value: &str) -> Result<Self, error::CmdError> {
+        let locator = format!("[name='{}']", field);
+        let locator = Locator::Css(&locator);
+        self.set(locator, value).await
+    }
+}
+
+impl Form {
+    /// Submit this form using the first available submit button.
+    ///
+    /// `false` is returned if no submit button was not found.
+    pub async fn submit(self) -> Result<Client, error::CmdError> {
+        self.submit_with(Locator::Css("input[type=submit],button[type=submit]"))
+            .await
+    }
+
+    /// Submit this form using the button matched by the given selector.
+    ///
+    /// `false` is returned if a matching button was not found.
+    pub async fn submit_with(mut self, button: Locator<'_>) -> Result<Client, error::CmdError> {
+        let locator = WebDriverCommand::FindElementElement(self.form, button.into());
+        let res = self.client.issue(locator).await?;
+        let submit = self.client.parse_lookup(res)?;
+        let res = self
+            .client
+            .issue(WebDriverCommand::ElementClick(submit))
+            .await?;
+        if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+            // geckodriver returns {} :(
+            Ok(self.client)
+        } else {
+            Err(error::CmdError::NotW3C(res))
+        }
+    }
+
+    /// Submit this form using the form submit button with the given label (case-insensitive).
+    ///
+    /// `false` is returned if a matching button was not found.
+    pub async fn submit_using(self, button_label: &str) -> Result<Client, error::CmdError> {
+        let escaped = button_label.replace('\\', "\\\\").replace('"', "\\\"");
+        let btn = format!(
+            "input[type=submit][value=\"{}\" i],\
+             button[type=submit][value=\"{}\" i]",
+            escaped, escaped
+        );
+        self.submit_with(Locator::Css(&btn)).await
+    }
+
+    /// Submit this form directly, without clicking any buttons.
+    ///
+    /// This can be useful to bypass forms that perform various magic when the submit button is
+    /// clicked, or that hijack click events altogether (yes, I'm looking at you online
+    /// advertisement code).
+    ///
+    /// Note that since no button is actually clicked, the `name=value` pair for the submit button
+    /// will not be submitted. This can be circumvented by using `submit_sneaky` instead.
+    pub async fn submit_direct(mut self) -> Result<Client, error::CmdError> {
+        let mut args = vec![via_json!(&self.form)];
+        self.client.fixup_elements(&mut args);
+        // some sites are silly, and name their submit button "submit". this ends up overwriting
+        // the "submit" function of the form with a reference to the submit button itself, so we
+        // can't call .submit(). we get around this by creating a *new* form, and using *its*
+        // submit() handler but with this pointed to the real form. solution from here:
+        // https://stackoverflow.com/q/833032/472927#comment23038712_834197
+        let cmd = webdriver::command::JavascriptCommandParameters {
+            script: "document.createElement('form').submit.call(arguments[0])".to_string(),
+            args: Some(args),
+        };
+
+        let res = self
+            .client
+            .issue(WebDriverCommand::ExecuteScript(cmd))
+            .await?;
+        if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+            // geckodriver returns {} :(
+            Ok(self.client)
+        } else {
+            Err(error::CmdError::NotW3C(res))
+        }
+    }
+
+    /// Submit this form directly, without clicking any buttons, and with an extra field.
+    ///
+    /// Like `submit_direct`, this method will submit this form without clicking a submit button.
+    /// However, it will *also* inject a hidden input element on the page that carries the given
+    /// `field=value` mapping. This allows you to emulate the form data as it would have been *if*
+    /// the submit button was indeed clicked.
+    pub async fn submit_sneaky(
+        mut self,
+        field: &str,
+        value: &str,
+    ) -> Result<Client, error::CmdError> {
+        let mut args = vec![via_json!(&self.form), Json::from(field), Json::from(value)];
+        self.client.fixup_elements(&mut args);
+        let cmd = webdriver::command::JavascriptCommandParameters {
+            script: "\
+                     var h = document.createElement('input');\
+                     h.setAttribute('type', 'hidden');\
+                     h.setAttribute('name', arguments[1]);\
+                     h.value = arguments[2];\
+                     arguments[0].appendChild(h)"
+                .to_string(),
+            args: Some(args),
+        };
+
+        let res = self
+            .client
+            .issue(WebDriverCommand::ExecuteScript(cmd))
+            .await?;
+        if res.is_null() | res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
+            // geckodriver returns {} :(
+            Form {
+                form: self.form,
+                client: self.client,
+            }
+            .submit_direct()
+            .await
+        } else {
+            Err(error::CmdError::NotW3C(res))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
 //! let src = img.attr("src").await?.expect("image should have a src");
 //! // now build a raw HTTP client request (which also has all current cookies)
-//! let raw = img.client().raw_client_for(fantoccini::Method::GET, &src).await?;
+//! let raw = img.client().raw_client_for(hyper::Method::GET, &src).await?;
 //!
 //! // we then read out the image bytes
 //! use futures_util::TryStreamExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-//! A high-level API for programmatically interacting with web pages through WebDriver.
+//! A medium-level API for programmatically interacting with web pages through WebDriver.
 //!
 //! This crate uses the [WebDriver protocol] to drive a conforming (potentially headless) browser
-//! through relatively high-level operations such as "click this element", "submit this form", etc.
+//! through relatively operations such as "click this element", "submit this form", etc.
 //!
 //! Most interactions are driven by using [CSS selectors]. With most WebDriver-compatible browser
 //! being fairly recent, the more expressive levels of the CSS standard are also supported, giving
@@ -14,9 +14,11 @@
 //! source code, and `Client::raw_client_for` to build a raw HTTP request for a particular URL.
 //!
 //! # Feature flags
-//! - `rustls-tls`: Use rustls for https, enabled by default
-//! - `openssl-tls`: Use openssl for https
 //!
+//! The following feature flags exist for this crate.
+//!
+//! - `native-tls`: Enable [ergonomic https connection](ClientBuilder::native) using [`native-tls`](https://crates.io/crates/native-tls) (enabled by default).
+//! - `rustls-tls`: Enable [ergonomic https connection](ClientBuilder::rustls) using Rusttls.
 //!
 //! # Examples
 //!
@@ -32,19 +34,19 @@
 //! Let's start out clicking around on Wikipedia:
 //!
 //! ```no_run
-//! # #![cfg(feature = "rustls-tls")]
-//! # extern crate tokio;
-//! # extern crate fantoccini;
-//! use fantoccini::ClientBuilder;
-//! use fantoccini::Locator;
+//! use fantoccini::{ClientBuilder, Locator};
 //!
 //! // let's set up the sequence of steps we want the browser to take
 //! #[tokio::main]
 //! async fn main() -> Result<(), fantoccini::error::CmdError> {
-//!     // With feature `rustls-tls`
+//!     // Connecting using "native" TLS (with feature `native-tls`; on by default)
+//!     # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+//!     let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//!     // Connecting using Rustls (with feature `rustls-tls`)
+//!     # #[cfg(feature = "rustls-tls")]
 //!     let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
-//!     // With `openssl-tls` enabled
-//!     // let mut c = ClientBuilder::openssl().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//!     # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
+//!     # let mut c: fantoccini::Client = unreachable!("no tls provider available");
 //!
 //!     // first, go to the Wikipedia page for Foobar
 //!     c.goto("https://en.wikipedia.org/wiki/Foobar").await?;
@@ -68,15 +70,15 @@
 //! Let's make the program do that for us instead:
 //!
 //! ```no_run
-//! # #![cfg(feature = "rustls-tls")]
-//! # extern crate tokio;
-//! # extern crate fantoccini;
-//! # use fantoccini::Locator;
-//! # use fantoccini::ClientBuilder;
-//!
+//! # use fantoccini::{ClientBuilder, Locator};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), fantoccini::error::CmdError> {
+//! # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+//! # let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # #[cfg(feature = "rustls-tls")]
 //! # let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
+//! # let mut c: fantoccini::Client = unreachable!("no tls provider available");
 //! // -- snip wrapper code --
 //! // go to the Wikipedia frontpage this time
 //! c.goto("https://www.wikipedia.org/").await?;
@@ -97,15 +99,15 @@
 //! What if we want to download a raw file? Fantoccini has you covered:
 //!
 //! ```no_run
-//! # #![cfg(feature = "rustls-tls")]
-//! # extern crate tokio;
-//! # extern crate futures_util;
-//! # extern crate fantoccini;
-//! # use fantoccini::ClientBuilder;
-//! # use fantoccini::Locator;
+//! # use fantoccini::{ClientBuilder, Locator};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), fantoccini::error::CmdError> {
+//! # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+//! # let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # #[cfg(feature = "rustls-tls")]
 //! # let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
+//! # let mut c: fantoccini::Client = unreachable!("no tls provider available");
 //! // -- snip wrapper code --
 //! // go back to the frontpage
 //! c.goto("https://www.wikipedia.org/").await?;
@@ -136,20 +138,13 @@
 //! [WebDriver compatible]: https://github.com/Fyrd/caniuse/issues/2757#issuecomment-304529217
 //! [`geckodriver`]: https://github.com/mozilla/geckodriver
 #![deny(missing_docs)]
-#![warn(missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    missing_debug_implementations,
+    rust_2018_idioms,
+    broken_intra_doc_links
+)]
 
 use hyper::client::connect;
-use serde::Serialize;
-use serde_json::Value as Json;
-use std::convert::TryFrom;
-use std::future::Future;
-use tokio::sync::oneshot;
-use webdriver::command::{
-    NewWindowParameters, SendKeysParameters, SwitchToFrameParameters, SwitchToWindowParameters,
-    WebDriverCommand,
-};
-use webdriver::common::{FrameId, ELEMENT_KEY};
-use webdriver::error::WebDriverError;
 
 macro_rules! via_json {
     ($x:expr) => {{
@@ -157,16 +152,21 @@ macro_rules! via_json {
     }};
 }
 
-pub use hyper::Method;
-
 /// Error types.
 pub mod error;
 
 /// The long-running session future we spawn for multiplexing onto a running WebDriver instance.
 mod session;
-use crate::session::{Cmd, Session};
 
-/// Builder pattern for Client
+/// A [builder] for WebDriver [`Client`] instances.
+///
+/// You will likely want to use [`native`](ClientBuilder::native) or
+/// [`rustls`](ClientBuilder::rustls) (depending on your preference) to start the builder. If you
+/// want to supply your own connector, use [`new`](ClientBuilder::new).
+///
+/// To connect to the WebDriver instance, call [`connect`](ClientBuilder::connect).
+///
+/// [builder]: https://rust-lang.github.io/api-guidelines/type-safety.html#c-builder
 #[derive(Default, Clone, Debug)]
 pub struct ClientBuilder<C>
 where
@@ -177,17 +177,19 @@ where
 }
 
 #[cfg(feature = "rustls-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
 impl ClientBuilder<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
-    /// Create a builder with Rustls connector, available with feature `rustls-tls`
+    /// Build a [`Client`] that will connect using [Rustls](https://crates.io/crates/rustls).
     pub fn rustls() -> Self {
         Self::new(hyper_rustls::HttpsConnector::with_native_roots())
     }
 }
 
-#[cfg(feature = "openssl-tls")]
+#[cfg(feature = "native-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
 impl ClientBuilder<hyper_tls::HttpsConnector<hyper::client::HttpConnector>> {
-    /// Create a builder with OpenSSL connector, available with feature `openssl-tls`
-    pub fn openssl() -> Self {
+    /// Build a [`Client`] that will connect using [`native-tls`](https://crates.io/crates/native-tls).
+    pub fn native() -> Self {
         Self::new(hyper_tls::HttpsConnector::new())
     }
 }
@@ -195,19 +197,44 @@ impl<C> ClientBuilder<C>
 where
     C: connect::Connect + Send + Sync + Clone + Unpin + 'static,
 {
-    /// Create a new builder using `connector` as the TLS connector
+    /// Build a [`Client`] that will connect using the given HTTP `connector`.
     pub fn new(connector: C) -> Self {
         Self {
             capabilities: None,
             connector,
         }
     }
+
     /// Pass the given WebDriver capabilities to the browser.
+    ///
+    /// The WebDriver specification has a list of [standard
+    /// capabilities](https://www.w3.org/TR/webdriver1/#capabilities), which are given below. In
+    /// addition, most browser vendors support a number of browser-specific capabilities stored
+    /// in an object under a prefixed key like
+    /// [`moz:firefoxOptions`](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions)
+    /// or
+    /// [`goog:chromeOptions`](https://sites.google.com/a/chromium.org/chromedriver/capabilities).
+    ///
+    /// The standard options are given below. See the
+    /// [specification](https://www.w3.org/TR/webdriver1/#capabilities) for more details.
+    ///
+    /// | Capability | Key | Value Type | Description |
+    /// |------------|-----|------------|-------------|
+    /// | Browser name | `"browserName"` | string | Identifies the user agent. |
+    /// | Browser version | `"browserVersion"` | string | Identifies the version of the user agent. |
+    /// | Platform name | `"platformName"` | string | Identifies the operating system of the endpoint node. |
+    /// | Accept insecure TLS certificates | `"acceptInsecureCerts"` | boolean | Indicates whether untrusted and self-signed TLS certificates are implicitly trusted on navigation for the duration of the session. |
+    /// | Page load strategy | `"pageLoadStrategy"` | string | Defines the current session’s page load strategy. |
+    /// | Proxy configuration | `"proxy"` | JSON Object | Defines the current session’s proxy configuration. |
+    /// | Window dimensioning/positioning | `"setWindowRect"` | boolean | Indicates whether the remote end supports all of the commands in Resizing and Positioning Windows. |
+    /// | Session timeouts configuration | `"timeouts"` | JSON Object | Describes the timeouts imposed on certain session operations. |
+    /// | Unhandled prompt behavior | `"unhandledPromptBehavior"` | string | Describes the current session’s user prompt handler. |
     pub fn capabilities(&mut self, cap: webdriver::capabilities::Capabilities) -> &mut Self {
         self.capabilities = Some(cap);
         self
     }
-    /// Connect to the session at the `webdriver` url
+
+    /// Connect to the WebDriver session at the `webdriver` URL.
     pub async fn connect(&self, webdriver: &str) -> Result<Client, error::NewSessionError> {
         if let Some(ref cap) = self.capabilities {
             Client::with_capabilities_and_connector(webdriver, cap, self.connector.clone()).await
@@ -219,13 +246,13 @@ where
 
 /// An element locator.
 ///
-/// See <https://www.w3.org/TR/webdriver/#element-retrieval>.
+/// See [the specification](https://www.w3.org/TR/webdriver1/#locator-strategies) for more details.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum Locator<'a> {
-    /// Find an element matching the given CSS selector.
+    /// Find an element matching the given [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
     Css(&'a str),
 
-    /// Find an element using the given `id`
+    /// Find an element using the given [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
     Id(&'a str),
 
     /// Find a link element with the given link text.
@@ -233,7 +260,10 @@ pub enum Locator<'a> {
     /// The text matching is exact.
     LinkText(&'a str),
 
-    /// Find an element using the given XPath expression.
+    /// Find an element using the given [XPath expression](https://developer.mozilla.org/en-US/docs/Web/XPath).
+    ///
+    /// You can address pretty much any element this way, if you're willing to put in the time to
+    /// find the right XPath.
     XPath(&'a str),
 }
 
@@ -260,1144 +290,7 @@ impl<'a> From<Locator<'a>> for webdriver::command::LocatorParameters {
     }
 }
 
-pub use crate::session::Client;
+mod client;
+pub use client::Client;
 
-/// A single element on the current page.
-#[derive(Clone, Debug, Serialize)]
-pub struct Element {
-    #[serde(skip_serializing)]
-    client: Client,
-    #[serde(flatten)]
-    element: webdriver::common::WebElement,
-}
-
-/// An HTML form on the current page.
-#[derive(Clone, Debug)]
-pub struct Form {
-    client: Client,
-    form: webdriver::common::WebElement,
-}
-
-impl Client {
-    /// Connect to the WebDriver host running the given address.
-    ///
-    /// The provided `connector` is used to establish the connection to the WebDriver host,
-    /// and should generally be one that supports HTTPS, as that is commonly required by WebDriver implementations.
-    ///
-    /// Calls `with_capabilities_and_connector` with an empty capabilities list.
-    pub async fn new_with_connector<C>(
-        webdriver: &str,
-        connector: C,
-    ) -> Result<Self, error::NewSessionError>
-    where
-        C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
-    {
-        Self::with_capabilities_and_connector(
-            webdriver,
-            &webdriver::capabilities::Capabilities::new(),
-            connector,
-        )
-        .await
-    }
-
-    /// Connect to the WebDriver host running the given address.
-    ///
-    /// The given capabilities will be requested in `alwaysMatch` or `desiredCapabilities`
-    /// depending on the protocol version supported by the server.
-    ///
-    /// Returns a future that resolves to a handle for issuing additional WebDriver tasks.
-    ///
-    /// Note that most callers should explicitly call `Client::close`, and wait for the returned
-    /// future before exiting. Not doing so may result in the WebDriver session not being cleanly
-    /// closed, which is particularly important for some drivers, such as geckodriver, where
-    /// multiple simulatenous sessions are not supported. If `close` is not explicitly called, a
-    /// session close request will be spawned on the given `handle` when the last instance of this
-    /// `Client` is dropped.
-    pub async fn with_capabilities_and_connector<C>(
-        webdriver: &str,
-        cap: &webdriver::capabilities::Capabilities,
-        connector: C,
-    ) -> Result<Self, error::NewSessionError>
-    where
-        C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
-    {
-        Session::with_capabilities_and_connector(webdriver, cap, connector).await
-    }
-
-    /// Get the session ID assigned by the WebDriver server to this client.
-    pub async fn session_id(&mut self) -> Result<Option<String>, error::CmdError> {
-        match self.issue(Cmd::GetSessionId).await? {
-            Json::String(s) => Ok(Some(s)),
-            Json::Null => Ok(None),
-            v => unreachable!("response to GetSessionId was not a string: {:?}", v),
-        }
-    }
-
-    /// Set the User Agent string to use for all subsequent requests.
-    pub async fn set_ua<S: Into<String>>(&mut self, ua: S) -> Result<(), error::CmdError> {
-        self.issue(Cmd::SetUA(ua.into())).await?;
-        Ok(())
-    }
-
-    /// Get the current User Agent string.
-    pub async fn get_ua(&mut self) -> Result<Option<String>, error::CmdError> {
-        match self.issue(Cmd::GetUA).await? {
-            Json::String(s) => Ok(Some(s)),
-            Json::Null => Ok(None),
-            v => unreachable!("response to GetSessionId was not a string: {:?}", v),
-        }
-    }
-
-    /// Terminate the WebDriver session.
-    ///
-    /// Normally, a shutdown of the WebDriver connection will be initiated when the last clone of a
-    /// `Client` is dropped. Specifically, the shutdown request will be issued using the tokio
-    /// `Handle` given when creating this `Client`. This in turn means that any errors will be
-    /// dropped.
-    ///
-    /// This function is safe to call multiple times, but once it has been called on one instance
-    /// of a `Client`, all requests to other instances of that `Client` will fail.
-    ///
-    /// This function may be useful in conjunction with `raw_client_for`, as it allows you to close
-    /// the automated browser window while doing e.g., a large download.
-    pub async fn close(&mut self) -> Result<(), error::CmdError> {
-        self.issue(Cmd::Shutdown).await?;
-        Ok(())
-    }
-
-    /// Mark this client's session as persistent.
-    ///
-    /// After all instances of a `Client` have been dropped, we normally shut down the WebDriver
-    /// session, which also closes the associated browser window or tab. By calling this method,
-    /// the shutdown command will _not_ be sent to this client's session, meaning its window or tab
-    /// will remain open.
-    ///
-    /// Note that an explicit call to [`Client::close`] will still terminate the session.
-    ///
-    /// This function is safe to call multiple times.
-    pub async fn persist(&mut self) -> Result<(), error::CmdError> {
-        self.issue(Cmd::Persist).await?;
-        Ok(())
-    }
-
-    /// Sets the x, y, width, and height properties of the current window.
-    pub async fn set_window_rect(
-        &mut self,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-    ) -> Result<(), error::CmdError> {
-        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
-            x: Some(x as i32),
-            y: Some(y as i32),
-            width: Some(width as i32),
-            height: Some(height as i32),
-        });
-
-        self.issue(cmd).await?;
-        Ok(())
-    }
-
-    /// Gets the x, y, width, and height properties of the current window.
-    pub async fn get_window_rect(&mut self) -> Result<(u64, u64, u64, u64), error::CmdError> {
-        match self.issue(WebDriverCommand::GetWindowRect).await? {
-            Json::Object(mut obj) => {
-                let x = match obj.remove("x").and_then(|x| x.as_u64()) {
-                    Some(x) => x,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let y = match obj.remove("y").and_then(|y| y.as_u64()) {
-                    Some(y) => y,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let width = match obj.remove("width").and_then(|width| width.as_u64()) {
-                    Some(width) => width,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let height = match obj.remove("height").and_then(|height| height.as_u64()) {
-                    Some(height) => height,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                Ok((x, y, width, height))
-            }
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Sets the x, y, width, and height properties of the current window.
-    pub async fn set_window_size(
-        &mut self,
-        width: u32,
-        height: u32,
-    ) -> Result<(), error::CmdError> {
-        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
-            x: None,
-            y: None,
-            width: Some(width as i32),
-            height: Some(height as i32),
-        });
-
-        self.issue(cmd).await?;
-        Ok(())
-    }
-
-    /// Gets the width and height of the current window.
-    pub async fn get_window_size(&mut self) -> Result<(u64, u64), error::CmdError> {
-        match self.issue(WebDriverCommand::GetWindowRect).await? {
-            Json::Object(mut obj) => {
-                let width = match obj.remove("width").and_then(|width| width.as_u64()) {
-                    Some(width) => width,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let height = match obj.remove("height").and_then(|height| height.as_u64()) {
-                    Some(height) => height,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                Ok((width, height))
-            }
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Sets the x, y, width, and height properties of the current window.
-    pub async fn set_window_position(&mut self, x: u32, y: u32) -> Result<(), error::CmdError> {
-        let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
-            x: Some(x as i32),
-            y: Some(y as i32),
-            width: None,
-            height: None,
-        });
-
-        self.issue(cmd).await?;
-        Ok(())
-    }
-
-    /// Gets the x and y top-left coordinate of the current window.
-    pub async fn get_window_position(&mut self) -> Result<(u64, u64), error::CmdError> {
-        match self.issue(WebDriverCommand::GetWindowRect).await? {
-            Json::Object(mut obj) => {
-                let x = match obj.remove("x").and_then(|x| x.as_u64()) {
-                    Some(x) => x,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let y = match obj.remove("y").and_then(|y| y.as_u64()) {
-                    Some(y) => y,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                Ok((x, y))
-            }
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Navigate directly to the given URL.
-    pub async fn goto(&mut self, url: &str) -> Result<(), error::CmdError> {
-        let url = url.to_owned();
-        let base = self.current_url_().await?;
-        let url = base.join(&url)?;
-        self.issue(WebDriverCommand::Get(webdriver::command::GetParameters {
-            url: url.into_string(),
-        }))
-        .await?;
-        Ok(())
-    }
-
-    async fn current_url_(&mut self) -> Result<url::Url, error::CmdError> {
-        let url = self.issue(WebDriverCommand::GetCurrentUrl).await?;
-        if let Some(url) = url.as_str() {
-            let url = if url.is_empty() { "about:blank" } else { url };
-            Ok(url.parse()?)
-        } else {
-            Err(error::CmdError::NotW3C(url))
-        }
-    }
-
-    /// Get the active element for this session.
-    ///
-    /// The "active" element is the `Element` within the DOM that currently has focus. This will
-    /// often be an `<input>` or `<textarea>` element that currently has the text selection, or
-    /// another input element such as a checkbox or radio button. Which elements are focusable
-    /// depends on the platform and browser configuration.
-    ///
-    /// If no element has focus, the result may be the page body or a `NoSuchElement` error.
-    pub async fn active_element(&mut self) -> Result<Element, error::CmdError> {
-        let res = self.issue(WebDriverCommand::GetActiveElement).await?;
-        let e = self.parse_lookup(res)?;
-        Ok(Element {
-            client: self.clone(),
-            element: e,
-        })
-    }
-
-    /// Retrieve the currently active URL for this session.
-    pub async fn current_url(&mut self) -> Result<url::Url, error::CmdError> {
-        self.current_url_().await
-    }
-
-    /// Get a PNG-encoded screenshot of the current page.
-    pub async fn screenshot(&mut self) -> Result<Vec<u8>, error::CmdError> {
-        let src = self.issue(WebDriverCommand::TakeScreenshot).await?;
-        if let Some(src) = src.as_str() {
-            base64::decode(src).map_err(error::CmdError::ImageDecodeError)
-        } else {
-            Err(error::CmdError::NotW3C(src))
-        }
-    }
-
-    /// Get the HTML source for the current page.
-    pub async fn source(&mut self) -> Result<String, error::CmdError> {
-        let src = self.issue(WebDriverCommand::GetPageSource).await?;
-        if let Some(src) = src.as_str() {
-            Ok(src.to_string())
-        } else {
-            Err(error::CmdError::NotW3C(src))
-        }
-    }
-
-    /// Go back to the previous page.
-    pub async fn back(&mut self) -> Result<(), error::CmdError> {
-        self.issue(WebDriverCommand::GoBack).await?;
-        Ok(())
-    }
-
-    /// Refresh the current previous page.
-    pub async fn refresh(&mut self) -> Result<(), error::CmdError> {
-        self.issue(WebDriverCommand::Refresh).await?;
-        Ok(())
-    }
-
-    /// Execute the given JavaScript `script` in the current browser session.
-    ///
-    /// `args` is available to the script inside the `arguments` array. Since `Element` implements
-    /// `Serialize`, you can also provide serialized `Element`s as arguments, and they will
-    /// correctly deserialize to DOM elements on the other side.
-    ///
-    /// To retrieve the value of a variable, `return` has to be used in the JavaScript code.
-    pub async fn execute(
-        &mut self,
-        script: &str,
-        mut args: Vec<Json>,
-    ) -> Result<Json, error::CmdError> {
-        self.fixup_elements(&mut args);
-        let cmd = webdriver::command::JavascriptCommandParameters {
-            script: script.to_string(),
-            args: Some(args),
-        };
-
-        self.issue(WebDriverCommand::ExecuteScript(cmd)).await
-    }
-
-    /// Execute the given async JavaScript `script` in the current browser session.
-    ///
-    /// The provided JavaScript has access to `args` through the JavaScript variable `arguments`.
-    /// The `arguments` array also holds an additional element at the end that provides a completion callback
-    /// for the asynchronous code.
-    ///
-    /// Since `Element` implements `Serialize`, you can also provide serialized `Element`s as arguments, and they will
-    /// correctly deserialize to DOM elements on the other side.
-    ///
-    /// # Examples
-    ///
-    /// Call a web API from the browser and retrieve the value asynchronously
-    ///
-    /// ```ignore
-    /// const JS: &'static str = r#"
-    ///     const [date, callback] = arguments;
-    ///
-    ///     fetch(`http://weather.api/${date}/hourly`)
-    ///     // whenever the HTTP Request completes,
-    ///     // send the value back to the Rust context
-    ///     .then(data => {
-    ///         callback(data.json())
-    ///     })
-    /// "#;
-    ///
-    /// let weather = client.execute_async(JS, vec![date]).await?;
-    /// ```
-    pub async fn execute_async(
-        &mut self,
-        script: &str,
-        mut args: Vec<Json>,
-    ) -> Result<Json, error::CmdError> {
-        self.fixup_elements(&mut args);
-        let cmd = webdriver::command::JavascriptCommandParameters {
-            script: script.to_string(),
-            args: Some(args),
-        };
-
-        self.issue(WebDriverCommand::ExecuteAsyncScript(cmd)).await
-    }
-
-    /// Issue an HTTP request to the given `url` with all the same cookies as the current session.
-    ///
-    /// Calling this method is equivalent to calling `with_raw_client_for` with an empty closure.
-    pub async fn raw_client_for(
-        &mut self,
-        method: Method,
-        url: &str,
-    ) -> Result<hyper::Response<hyper::Body>, error::CmdError> {
-        self.with_raw_client_for(method, url, |req| req.body(hyper::Body::empty()).unwrap())
-            .await
-    }
-
-    /// Build and issue an HTTP request to the given `url` with all the same cookies as the current
-    /// session.
-    ///
-    /// Before the HTTP request is issued, the given `before` closure will be called with a handle
-    /// to the `Request` about to be sent.
-    pub async fn with_raw_client_for<F>(
-        &mut self,
-        method: Method,
-        url: &str,
-        before: F,
-    ) -> Result<hyper::Response<hyper::Body>, error::CmdError>
-    where
-        F: FnOnce(http::request::Builder) -> hyper::Request<hyper::Body>,
-    {
-        let url = url.to_owned();
-        // We need to do some trickiness here. GetCookies will only give us the cookies for the
-        // *current* domain, whereas we want the cookies for `url`'s domain. So, we navigate to the
-        // URL in question, fetch its cookies, and then navigate back. *Except* that we can't do
-        // that either (what if `url` is some huge file?). So we *actually* navigate to some weird
-        // url that's unlikely to exist on the target doamin, and which won't resolve into the
-        // actual content, but will still give the same cookies.
-        //
-        // The fact that cookies can have /path and security constraints makes this even more of a
-        // pain. /path in particular is tricky, because you could have a URL like:
-        //
-        //    example.com/download/some_identifier/ignored_filename_just_for_show
-        //
-        // Imagine if a cookie is set with path=/download/some_identifier. How do we get that
-        // cookie without triggering a request for the (large) file? I don't know. Hence: TODO.
-        let old_url = self.current_url_().await?;
-        let url = old_url.clone().join(&url)?;
-        let cookie_url = url.clone().join("/please_give_me_your_cookies")?;
-        self.goto(cookie_url.as_str()).await?;
-
-        // TODO: go back before we return if this call errors:
-        let cookies = self.issue(WebDriverCommand::GetCookies).await?;
-        if !cookies.is_array() {
-            return Err(error::CmdError::NotW3C(cookies));
-        }
-        self.back().await?;
-        let ua = self.get_ua().await?;
-
-        // now add all the cookies
-        let mut all_ok = true;
-        let mut jar = Vec::new();
-        for cookie in cookies.as_array().unwrap() {
-            if !cookie.is_object() {
-                all_ok = false;
-                break;
-            }
-
-            // https://w3c.github.io/webdriver/webdriver-spec.html#cookies
-            let cookie = cookie.as_object().unwrap();
-            if !cookie.contains_key("name") || !cookie.contains_key("value") {
-                all_ok = false;
-                break;
-            }
-
-            if !cookie["name"].is_string() || !cookie["value"].is_string() {
-                all_ok = false;
-                break;
-            }
-
-            // Note that since we're sending these cookies, all that matters is the mapping
-            // from name to value. The other fields only matter when deciding whether to
-            // include a cookie or not, and the driver has already decided that for us
-            // (GetCookies is for a particular URL).
-            jar.push(
-                cookie::Cookie::new(
-                    cookie["name"].as_str().unwrap().to_owned(),
-                    cookie["value"].as_str().unwrap().to_owned(),
-                )
-                .encoded()
-                .to_string(),
-            );
-        }
-
-        if !all_ok {
-            return Err(error::CmdError::NotW3C(cookies));
-        }
-
-        let mut req = hyper::Request::builder();
-        req = req
-            .method(method)
-            .uri(http::Uri::try_from(url.as_str()).unwrap());
-        req = req.header(hyper::header::COOKIE, jar.join("; "));
-        if let Some(s) = ua {
-            req = req.header(hyper::header::USER_AGENT, s);
-        }
-        let req = before(req);
-        let (tx, rx) = oneshot::channel();
-        self.issue(Cmd::Raw { req, rsp: tx }).await?;
-        match rx.await {
-            Ok(Ok(r)) => Ok(r),
-            Ok(Err(e)) => Err(e.into()),
-            Err(e) => unreachable!("Session ended prematurely: {:?}", e),
-        }
-    }
-
-    /// Switches to the frame specified at the index.
-    pub async fn enter_frame(mut self, index: Option<u16>) -> Result<Client, error::CmdError> {
-        let params = SwitchToFrameParameters {
-            id: index.map(FrameId::Short),
-        };
-        self.issue(WebDriverCommand::SwitchToFrame(params)).await?;
-        Ok(self)
-    }
-
-    /// Switches to the parent of the frame the client is currently contained within.
-    pub async fn enter_parent_frame(mut self) -> Result<Client, error::CmdError> {
-        self.issue(WebDriverCommand::SwitchToParentFrame).await?;
-        Ok(self)
-    }
-
-    /// Find an element on the page.
-    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
-        self.by(search.into()).await
-    }
-
-    /// Find elements on the page.
-    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
-        let res = self
-            .issue(WebDriverCommand::FindElements(search.into()))
-            .await?;
-        let array = self.parse_lookup_all(res)?;
-        Ok(array
-            .into_iter()
-            .map(move |e| Element {
-                client: self.clone(),
-                element: e,
-            })
-            .collect())
-    }
-
-    /// Wait for the given function to return `true` before proceeding.
-    ///
-    /// This can be useful to wait for something to appear on the page before interacting with it.
-    /// While this currently just spins and yields, it may be more efficient than this in the
-    /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
-    /// the page.
-    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
-    where
-        F: FnMut(&mut Client) -> FF,
-        FF: Future<Output = Result<bool, error::CmdError>>,
-    {
-        while !is_ready(self).await? {}
-        Ok(())
-    }
-
-    /// Wait for the given element to be present on the page.
-    ///
-    /// This can be useful to wait for something to appear on the page before interacting with it.
-    /// While this currently just spins and yields, it may be more efficient than this in the
-    /// future. In particular, in time, it may only run `is_ready` again when an event occurs on
-    /// the page.
-    pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
-        let s: webdriver::command::LocatorParameters = search.into();
-        loop {
-            match self
-                .by(webdriver::command::LocatorParameters {
-                    using: s.using,
-                    value: s.value.clone(),
-                })
-                .await
-            {
-                Ok(v) => break Ok(v),
-                Err(error::CmdError::NoSuchElement(_)) => {}
-                Err(e) => break Err(e),
-            }
-        }
-    }
-
-    /// Wait for the page to navigate to a new URL before proceeding.
-    ///
-    /// If the `current` URL is not provided, `self.current_url()` will be used. Note however that
-    /// this introduces a race condition: the browser could finish navigating *before* we call
-    /// `current_url()`, which would lead to an eternal wait.
-    pub async fn wait_for_navigation(
-        &mut self,
-        current: Option<url::Url>,
-    ) -> Result<(), error::CmdError> {
-        let current = match current {
-            Some(current) => current,
-            None => self.current_url_().await?,
-        };
-
-        self.wait_for(move |c| {
-            // TODO: get rid of this clone
-            let current = current.clone();
-            // TODO: and this one too
-            let mut c = c.clone();
-            async move { Ok(c.current_url().await? != current) }
-        })
-        .await
-    }
-
-    /// Locate a form on the page.
-    ///
-    /// Through the returned `Form`, HTML forms can be filled out and submitted.
-    pub async fn form(&mut self, search: Locator<'_>) -> Result<Form, error::CmdError> {
-        let l = search.into();
-        let res = self.issue(WebDriverCommand::FindElement(l)).await?;
-        let f = self.parse_lookup(res)?;
-        Ok(Form {
-            client: self.clone(),
-            form: f,
-        })
-    }
-
-    /// Gets the current window handle.
-    pub async fn window(&mut self) -> Result<webdriver::common::WebWindow, error::CmdError> {
-        let res = self.issue(WebDriverCommand::GetWindowHandle).await?;
-        match res {
-            Json::String(x) => Ok(webdriver::common::WebWindow(x)),
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Gets a list of all active windows (and tabs)
-    pub async fn windows(&mut self) -> Result<Vec<webdriver::common::WebWindow>, error::CmdError> {
-        let res = self.issue(WebDriverCommand::GetWindowHandles).await?;
-        match res {
-            Json::Array(handles) => handles
-                .into_iter()
-                .map(|handle| match handle {
-                    Json::String(x) => Ok(webdriver::common::WebWindow(x)),
-                    v => Err(error::CmdError::NotW3C(v)),
-                })
-                .collect::<Result<Vec<_>, _>>(),
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Switches to the chosen window.
-    pub async fn switch_to_window(
-        &mut self,
-        window: webdriver::common::WebWindow,
-    ) -> Result<(), error::CmdError> {
-        let params = SwitchToWindowParameters { handle: window.0 };
-        let _res = self.issue(WebDriverCommand::SwitchToWindow(params)).await?;
-        Ok(())
-    }
-
-    /// Closes the current window.
-    ///
-    /// Will close the session if no other windows exist.
-    ///
-    /// Closing a window will not switch the client to one of the remaining windows.
-    /// The switching must be done by calling `switch_to_window` using a still live window
-    /// after the current window has been closed.
-    pub async fn close_window(&mut self) -> Result<(), error::CmdError> {
-        let _res = self.issue(WebDriverCommand::CloseWindow).await?;
-        Ok(())
-    }
-
-    /// Creates a new window. If `is_tab` is `true`, then a tab will be created instead.
-    ///
-    /// Requires geckodriver > 0.24 and firefox > 66
-    ///
-    /// Windows are treated the same as tabs by the webdriver protocol.
-    /// The functions `new_window`, `switch_to_window`, `close_window`, `window` and `windows`
-    /// all operate on both tabs and windows.
-    pub async fn new_window(
-        &mut self,
-        as_tab: bool,
-    ) -> Result<webdriver::response::NewWindowResponse, error::CmdError> {
-        let type_hint = if as_tab { "tab" } else { "window" }.to_string();
-        let type_hint = Some(type_hint);
-        let params = NewWindowParameters { type_hint };
-        match self.issue(WebDriverCommand::NewWindow(params)).await? {
-            Json::Object(mut obj) => {
-                let handle = match obj
-                    .remove("handle")
-                    .and_then(|x| x.as_str().map(String::from))
-                {
-                    Some(handle) => handle,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                let typ = match obj
-                    .remove("type")
-                    .and_then(|x| x.as_str().map(String::from))
-                {
-                    Some(typ) => typ,
-                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
-                };
-
-                Ok(webdriver::response::NewWindowResponse { handle, typ })
-            }
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    // helpers
-
-    async fn by(
-        &mut self,
-        locator: webdriver::command::LocatorParameters,
-    ) -> Result<Element, error::CmdError> {
-        let res = self.issue(WebDriverCommand::FindElement(locator)).await?;
-        let e = self.parse_lookup(res)?;
-        Ok(Element {
-            client: self.clone(),
-            element: e,
-        })
-    }
-
-    /// Extract the `WebElement` from a `FindElement` or `FindElementElement` command.
-    fn parse_lookup(&self, res: Json) -> Result<webdriver::common::WebElement, error::CmdError> {
-        let mut res = match res {
-            Json::Object(o) => o,
-            res => return Err(error::CmdError::NotW3C(res)),
-        };
-
-        // legacy protocol uses "ELEMENT" as identifier
-        let key = if self.is_legacy() {
-            "ELEMENT"
-        } else {
-            ELEMENT_KEY
-        };
-
-        if !res.contains_key(key) {
-            return Err(error::CmdError::NotW3C(Json::Object(res)));
-        }
-
-        match res.remove(key) {
-            Some(Json::String(wei)) => {
-                return Ok(webdriver::common::WebElement(wei));
-            }
-            Some(v) => {
-                res.insert(key.to_string(), v);
-            }
-            None => {}
-        }
-
-        Err(error::CmdError::NotW3C(Json::Object(res)))
-    }
-
-    /// Extract `WebElement`s from a `FindElements` or `FindElementElements` command.
-    fn parse_lookup_all(
-        &self,
-        res: Json,
-    ) -> Result<Vec<webdriver::common::WebElement>, error::CmdError> {
-        let res = match res {
-            Json::Array(a) => a,
-            res => return Err(error::CmdError::NotW3C(res)),
-        };
-
-        let mut array = Vec::new();
-        for json in res {
-            let e = self.parse_lookup(json)?;
-            array.push(e);
-        }
-
-        Ok(array)
-    }
-
-    fn fixup_elements(&self, args: &mut [Json]) {
-        if self.is_legacy() {
-            for arg in args {
-                // the serialization of WebElement uses the W3C index,
-                // but legacy implementations need us to use the "ELEMENT" index
-                if let Json::Object(ref mut o) = *arg {
-                    if let Some(wei) = o.remove(ELEMENT_KEY) {
-                        o.insert("ELEMENT".to_string(), wei);
-                    }
-                }
-            }
-        }
-    }
-}
-
-impl Element {
-    /// Look up an [attribute] value for this element by name.
-    ///
-    /// `Ok(None)` is returned if the element does not have the given attribute.
-    ///
-    /// [attribute]: https://dom.spec.whatwg.org/#concept-attribute
-    pub async fn attr(&mut self, attribute: &str) -> Result<Option<String>, error::CmdError> {
-        let cmd =
-            WebDriverCommand::GetElementAttribute(self.element.clone(), attribute.to_string());
-        match self.client.issue(cmd).await? {
-            Json::String(v) => Ok(Some(v)),
-            Json::Null => Ok(None),
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Look up a DOM [property] for this element by name.
-    ///
-    /// `Ok(None)` is returned if the element does not have the given property.
-    ///
-    /// [property]: https://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1
-    pub async fn prop(&mut self, prop: &str) -> Result<Option<String>, error::CmdError> {
-        let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());
-        match self.client.issue(cmd).await? {
-            Json::String(v) => Ok(Some(v)),
-            Json::Null => Ok(None),
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Retrieve the text contents of this elment.
-    pub async fn text(&mut self) -> Result<String, error::CmdError> {
-        let cmd = WebDriverCommand::GetElementText(self.element.clone());
-        match self.client.issue(cmd).await? {
-            Json::String(v) => Ok(v),
-            v => Err(error::CmdError::NotW3C(v)),
-        }
-    }
-
-    /// Retrieve the HTML contents of this element.
-    ///
-    /// `inner` dictates whether the wrapping node's HTML is excluded or not. For example, take the
-    /// HTML:
-    ///
-    /// ```html
-    /// <div id="foo"><hr /></div>
-    /// ```
-    ///
-    /// With `inner = true`, `<hr />` would be returned. With `inner = false`,
-    /// `<div id="foo"><hr /></div>` would be returned instead.
-    pub async fn html(&mut self, inner: bool) -> Result<String, error::CmdError> {
-        let prop = if inner { "innerHTML" } else { "outerHTML" };
-        Ok(self.prop(prop).await?.unwrap())
-    }
-
-    /// Find the first matching descendant element.
-    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
-        let res = self
-            .client
-            .issue(WebDriverCommand::FindElementElement(
-                self.element.clone(),
-                search.into(),
-            ))
-            .await?;
-        let e = self.client.parse_lookup(res)?;
-        Ok(Element {
-            client: self.client.clone(),
-            element: e,
-        })
-    }
-    /// Find all matching descendant elements.
-    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
-        let res = self
-            .client
-            .issue(WebDriverCommand::FindElementElements(
-                self.element.clone(),
-                search.into(),
-            ))
-            .await?;
-        let array = self.client.parse_lookup_all(res)?;
-        Ok(array
-            .into_iter()
-            .map(move |e| Element {
-                client: self.client.clone(),
-                element: e,
-            })
-            .collect())
-    }
-
-    /// Simulate the user clicking on this element.
-    ///
-    /// Note that since this *may* result in navigation, we give up the handle to the element.
-    pub async fn click(mut self) -> Result<Client, error::CmdError> {
-        let cmd = WebDriverCommand::ElementClick(self.element);
-        let r = self.client.issue(cmd).await?;
-        if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-            // geckodriver returns {} :(
-            Ok(self.client)
-        } else {
-            Err(error::CmdError::NotW3C(r))
-        }
-    }
-
-    /// Clear the value prop of this element
-    pub async fn clear(&mut self) -> Result<(), error::CmdError> {
-        let cmd = WebDriverCommand::ElementClear(self.element.clone());
-        let r = self.client.issue(cmd).await?;
-        if r.is_null() {
-            Ok(())
-        } else {
-            Err(error::CmdError::NotW3C(r))
-        }
-    }
-
-    /// Simulate the user sending keys to an element.
-    pub async fn send_keys(&mut self, text: &str) -> Result<(), error::CmdError> {
-        let cmd = WebDriverCommand::ElementSendKeys(
-            self.element.clone(),
-            SendKeysParameters {
-                text: text.to_owned(),
-            },
-        );
-        let r = self.client.issue(cmd).await?;
-        if r.is_null() {
-            Ok(())
-        } else {
-            Err(error::CmdError::NotW3C(r))
-        }
-    }
-
-    /// Get back the [`Client`] hosting this `Element`.
-    pub fn client(self) -> Client {
-        self.client
-    }
-
-    /// Follow the `href` target of the element matching the given CSS selector *without* causing a
-    /// click interaction.
-    ///
-    /// Note that since this *may* result in navigation, we give up the handle to the element.
-    pub async fn follow(mut self) -> Result<Client, error::CmdError> {
-        let cmd = WebDriverCommand::GetElementAttribute(self.element, "href".to_string());
-        let href = self.client.issue(cmd).await?;
-        let href = match href {
-            Json::String(v) => v,
-            Json::Null => {
-                let e = WebDriverError::new(
-                    webdriver::error::ErrorStatus::InvalidArgument,
-                    "cannot follow element without href attribute",
-                );
-                return Err(error::CmdError::Standard(e));
-            }
-            v => return Err(error::CmdError::NotW3C(v)),
-        };
-
-        let url = self.client.current_url_().await?;
-        let href = url.join(&href)?;
-        self.client.goto(href.as_str()).await?;
-        Ok(self.client)
-    }
-
-    /// Find and click an `option` child element by its `value` attribute.
-    pub async fn select_by_value(mut self, value: &str) -> Result<Client, error::CmdError> {
-        let locator = format!("option[value='{}']", value);
-        let locator = webdriver::command::LocatorParameters {
-            using: webdriver::common::LocatorStrategy::CSSSelector,
-            value: locator,
-        };
-
-        let cmd = WebDriverCommand::FindElementElement(self.element, locator);
-        let v = self.client.issue(cmd).await?;
-        Element {
-            element: self.client.parse_lookup(v)?,
-            client: self.client,
-        }
-        .click()
-        .await
-    }
-
-    /// Find and click an `<option>` child element by its index.
-    ///
-    /// This method clicks the first `<option>` element that is an `index`th child
-    /// (`option:nth-of-type(index+1)`). This will be the `index`th `<option>`
-    /// element if the current element is a `<select>`. If you use this method on
-    /// an `Element` that is _not_ a `<select>` (such as on a full `<form>`), it
-    /// may not do what you expect if there are multiple `<select>` elements
-    /// in the form, or if it there are stray `<option>` in the form.
-    ///
-    /// The indexing in this method is 0-based.
-    pub async fn select_by_index(mut self, index: usize) -> Result<Client, error::CmdError> {
-        let locator = format!("option:nth-of-type({})", index + 1);
-
-        self.find(Locator::Css(&locator)).await?.click().await
-    }
-
-    /// Find and click an `<option>` element by its visible text.
-    ///
-    /// The method doesn't make any escaping for the argument like it is done in python webdriver client for [example].
-    /// It also doesn't make any normalizations before match.
-    ///
-    /// [example]: https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/py/selenium/webdriver/support/select.py#L67
-    pub async fn select_by_label(mut self, label: &str) -> Result<Client, error::CmdError> {
-        let locator = format!(r".//option[.='{}']", label);
-        self.find(Locator::XPath(&locator)).await?.click().await
-    }
-
-    /// Switches to the frame contained within the element.
-    pub async fn enter_frame(self) -> Result<Client, error::CmdError> {
-        let Self {
-            mut client,
-            element,
-        } = self;
-        let params = SwitchToFrameParameters {
-            id: Some(FrameId::Element(element)),
-        };
-        client
-            .issue(WebDriverCommand::SwitchToFrame(params))
-            .await?;
-        Ok(client)
-    }
-}
-
-impl Form {
-    /// Find a form input using the given `locator` and set its value to `value`.
-    pub async fn set(
-        &mut self,
-        locator: Locator<'_>,
-        value: &str,
-    ) -> Result<Self, error::CmdError> {
-        let locator = WebDriverCommand::FindElementElement(self.form.clone(), locator.into());
-        let value = Json::from(value);
-
-        let res = self.client.issue(locator).await?;
-        let field = self.client.parse_lookup(res)?;
-        let mut args = vec![via_json!(&field), value];
-        self.client.fixup_elements(&mut args);
-        let cmd = webdriver::command::JavascriptCommandParameters {
-            script: "arguments[0].value = arguments[1]".to_string(),
-            args: Some(args),
-        };
-
-        let res = self
-            .client
-            .issue(WebDriverCommand::ExecuteScript(cmd))
-            .await?;
-        if res.is_null() {
-            Ok(Form {
-                client: self.client.clone(),
-                form: self.form.clone(),
-            })
-        } else {
-            Err(error::CmdError::NotW3C(res))
-        }
-    }
-
-    /// Find a form input with the given `name` and set its value to `value`.
-    pub async fn set_by_name(&mut self, field: &str, value: &str) -> Result<Self, error::CmdError> {
-        let locator = format!("[name='{}']", field);
-        let locator = Locator::Css(&locator);
-        self.set(locator, value).await
-    }
-
-    /// Submit this form using the first available submit button.
-    ///
-    /// `false` is returned if no submit button was not found.
-    pub async fn submit(self) -> Result<Client, error::CmdError> {
-        self.submit_with(Locator::Css("input[type=submit],button[type=submit]"))
-            .await
-    }
-
-    /// Submit this form using the button matched by the given selector.
-    ///
-    /// `false` is returned if a matching button was not found.
-    pub async fn submit_with(mut self, button: Locator<'_>) -> Result<Client, error::CmdError> {
-        let locator = WebDriverCommand::FindElementElement(self.form, button.into());
-        let res = self.client.issue(locator).await?;
-        let submit = self.client.parse_lookup(res)?;
-        let res = self
-            .client
-            .issue(WebDriverCommand::ElementClick(submit))
-            .await?;
-        if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-            // geckodriver returns {} :(
-            Ok(self.client)
-        } else {
-            Err(error::CmdError::NotW3C(res))
-        }
-    }
-
-    /// Submit this form using the form submit button with the given label (case-insensitive).
-    ///
-    /// `false` is returned if a matching button was not found.
-    pub async fn submit_using(self, button_label: &str) -> Result<Client, error::CmdError> {
-        let escaped = button_label.replace('\\', "\\\\").replace('"', "\\\"");
-        let btn = format!(
-            "input[type=submit][value=\"{}\" i],\
-             button[type=submit][value=\"{}\" i]",
-            escaped, escaped
-        );
-        self.submit_with(Locator::Css(&btn)).await
-    }
-
-    /// Submit this form directly, without clicking any buttons.
-    ///
-    /// This can be useful to bypass forms that perform various magic when the submit button is
-    /// clicked, or that hijack click events altogether (yes, I'm looking at you online
-    /// advertisement code).
-    ///
-    /// Note that since no button is actually clicked, the `name=value` pair for the submit button
-    /// will not be submitted. This can be circumvented by using `submit_sneaky` instead.
-    pub async fn submit_direct(mut self) -> Result<Client, error::CmdError> {
-        let mut args = vec![via_json!(&self.form)];
-        self.client.fixup_elements(&mut args);
-        // some sites are silly, and name their submit button "submit". this ends up overwriting
-        // the "submit" function of the form with a reference to the submit button itself, so we
-        // can't call .submit(). we get around this by creating a *new* form, and using *its*
-        // submit() handler but with this pointed to the real form. solution from here:
-        // https://stackoverflow.com/q/833032/472927#comment23038712_834197
-        let cmd = webdriver::command::JavascriptCommandParameters {
-            script: "document.createElement('form').submit.call(arguments[0])".to_string(),
-            args: Some(args),
-        };
-
-        let res = self
-            .client
-            .issue(WebDriverCommand::ExecuteScript(cmd))
-            .await?;
-        if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-            // geckodriver returns {} :(
-            Ok(self.client)
-        } else {
-            Err(error::CmdError::NotW3C(res))
-        }
-    }
-
-    /// Submit this form directly, without clicking any buttons, and with an extra field.
-    ///
-    /// Like `submit_direct`, this method will submit this form without clicking a submit button.
-    /// However, it will *also* inject a hidden input element on the page that carries the given
-    /// `field=value` mapping. This allows you to emulate the form data as it would have been *if*
-    /// the submit button was indeed clicked.
-    pub async fn submit_sneaky(
-        mut self,
-        field: &str,
-        value: &str,
-    ) -> Result<Client, error::CmdError> {
-        let mut args = vec![via_json!(&self.form), Json::from(field), Json::from(value)];
-        self.client.fixup_elements(&mut args);
-        let cmd = webdriver::command::JavascriptCommandParameters {
-            script: "\
-                     var h = document.createElement('input');\
-                     h.setAttribute('type', 'hidden');\
-                     h.setAttribute('name', arguments[1]);\
-                     h.value = arguments[2];\
-                     arguments[0].appendChild(h)"
-                .to_string(),
-            args: Some(args),
-        };
-
-        let res = self
-            .client
-            .issue(WebDriverCommand::ExecuteScript(cmd))
-            .await?;
-        if res.is_null() | res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
-            // geckodriver returns {} :(
-            Form {
-                form: self.form,
-                client: self.client,
-            }
-            .submit_direct()
-            .await
-        } else {
-            Err(error::CmdError::NotW3C(res))
-        }
-    }
-
-    /// Get back the [`Client`] hosting this `Form`.
-    pub fn client(self) -> Client {
-        self.client
-    }
-}
+pub mod elements;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,4 +1,4 @@
-use crate::error;
+use crate::{error, Client};
 use futures_core::ready;
 use futures_util::future::{self, Either};
 use futures_util::{FutureExt, TryFutureExt};
@@ -16,13 +16,6 @@ use webdriver::error::ErrorStatus;
 use webdriver::error::WebDriverError;
 
 type Ack = oneshot::Sender<Result<Json, error::CmdError>>;
-
-/// A WebDriver client tied to a single browser session.
-#[derive(Clone, Debug)]
-pub struct Client {
-    tx: mpsc::UnboundedSender<Task>,
-    is_legacy: bool,
-}
 
 type Wcmd = WebDriverCommand<webdriver::command::VoidWebDriverExtensionCommand>;
 

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -1,9 +1,9 @@
 //! Tests that make use of external websites.
-#[macro_use]
-extern crate serial_test;
 
-use fantoccini::{error, Client, Locator, Method};
+use fantoccini::{error, Client, Locator};
 use futures_util::TryFutureExt;
+use hyper::Method;
+use serial_test::serial;
 use std::time::Duration;
 use url::Url;
 


### PR DESCRIPTION
The PR adds many more links to the WebDriver specification, tidies up
the features a little, re-organizes the big `src/lib.rs` into smaller
files, and splits up `impl` blocks (and `fn` order) to correspond to the
command order in the spec.