### PR TITLE
Add error type for pageload timeout

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -807,6 +807,7 @@ where
                             "unknown error" => ErrorStatus::UnknownError,
                             "script timeout" => ErrorStatus::ScriptTimeout,
                             "unsupported operation" => ErrorStatus::UnsupportedOperation,
+                            "timeout" => ErrorStatus::Timeout,
                             _ => unreachable!(
                                 "received unknown error ({}) for INTERNAL_SERVER_ERROR status code",
                                 error


### PR DESCRIPTION
Fixes #120.

As I wrote in the issue, the error occurred when `.goto()` was used on e.g. any URL redirecting to a download, which opens a download prompt (invisible when running headless), this seems to make geckodriver return with a timeout error because the "page" never loaded, i.e. the download. 

The error appeared after 5 minutes, which is exactly the default `pageLoad` timeout. After setting it to 5 seconds, it instead occurred *exactly* after 5 seconds. Based on this I believe this is the correct `ErrorStatus`, or at the very least this is better than dropping the connection without any ability to actually shutdown the still-alive session.

In any case, it works for me! One funny thing is that the download prompt remains forever instead of closing, but it keeps chugging along to the next page(s) and running all the code as usual. It could *possibly* be closed by using ActionChains and e.g. sending keydown Escape.