### PR TITLE
Add support for WebDriver cookie operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ hyper-rustls = { version = "0.22.1", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 mime = "0.3.9"
 http = "0.2"
+time = "0.2.26"
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "full" ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -513,53 +513,6 @@ impl Client {
     }
 }
 
-/// [Cookies](https://www.w3.org/TR/webdriver2/#cookies)
-impl Client {
-    /// Get all cookies associated with the current document.
-    ///
-    /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver2/#get-all-cookies) of the
-    /// WebDriver standard.
-    pub async fn get_all_cookies(&mut self) -> Result<Vec<Json>, error::CmdError> {
-        let resp = self.issue(WebDriverCommand::GetCookies).await?;
-        let raw_cookies = resp.as_array();
-
-        if raw_cookies.is_none() {
-            // We are expecting a JSON array of cookies at the top-level
-            let err =
-                error::CmdError::UnexpectedJson("expected a JSON array of cookie objects".to_string());
-            return Err(err);
-        }
-
-        let cookies = raw_cookies.unwrap().clone();
-
-        Ok(cookies)
-    }
-
-    /// Get a single named cookie associated with the current document.
-    ///
-    /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver2/#get-named-cookie) of the
-    /// WebDriver standard.
-    pub async fn get_named_cookie(&mut self, name: &str) -> Result<Json, error::CmdError> {
-        self.issue(WebDriverCommand::GetNamedCookie(name.to_string())).await
-    }
-
-    /// Delete a single cookie from the current document.
-    ///
-    /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver2/#delete-cookie) of the
-    /// WebDriver standard.
-    pub async fn delete_cookie(&mut self, name: &str) -> Result<Json, error::CmdError> {
-        self.issue(WebDriverCommand::DeleteCookie(name.to_string())).await
-    }
-
-    /// Delete all cookies from the current document.
-    ///
-    /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver2/#delete-all-cookies) of the
-    /// WebDriver standard.
-    pub async fn delete_all_cookies(&mut self) -> Result<Json, error::CmdError> {
-        self.issue(WebDriverCommand::DeleteCookies).await
-    }
-}
-
 /// [Document Handling](https://www.w3.org/TR/webdriver1/#document-handling)
 impl Client {
     /// Get the HTML source for the current page.

--- a/src/client.rs
+++ b/src/client.rs
@@ -539,45 +539,16 @@ impl Client {
     ///
     /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver2/#get-named-cookie) of the
     /// WebDriver standard.
-    pub async fn get_named_cookie(&mut self, name: String) -> Result<Json, error::CmdError> {
-        self.issue(WebDriverCommand::GetNamedCookie(name)).await
-    }
-
-    /// Add a single cookie to the current document.
-    ///
-    /// See [16.3 Add Cookie](https://www.w3.org/TR/webdriver2/#add-cookie) of the
-    /// WebDriver standard.
-    pub async fn add_cookie(
-        &mut self,
-        name: String,
-        value: String,
-        path: Option<String>,
-        domain: Option<String>,
-        secure: bool,
-        http_only: bool,
-        expiry: Option<u64>,
-        same_site: Option<String>,
-    ) -> Result<Json, error::CmdError> {
-        let params = webdriver::command::AddCookieParameters {
-            name,
-            value,
-            path,
-            domain,
-            secure,
-            httpOnly: http_only,
-            expiry: expiry.map(|v| webdriver::common::Date(v)),
-            sameSite: same_site,
-        };
-
-        self.issue(WebDriverCommand::AddCookie(params)).await
+    pub async fn get_named_cookie(&mut self, name: &str) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::GetNamedCookie(name.to_string())).await
     }
 
     /// Delete a single cookie from the current document.
     ///
     /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver2/#delete-cookie) of the
     /// WebDriver standard.
-    pub async fn delete_cookie(&mut self, name: String) -> Result<Json, error::CmdError> {
-        self.issue(WebDriverCommand::DeleteCookie(name)).await
+    pub async fn delete_cookie(&mut self, name: &str) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::DeleteCookie(name.to_string())).await
     }
 
     /// Delete all cookies from the current document.

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,7 +156,7 @@ impl Client {
         let base = self.current_url_().await?;
         let url = base.join(&url)?;
         self.issue(WebDriverCommand::Get(webdriver::command::GetParameters {
-            url: url.into_string(),
+            url: url.into(),
         }))
         .await?;
         Ok(())
@@ -510,6 +510,82 @@ impl Client {
             client: self.clone(),
             form: f,
         })
+    }
+}
+
+/// [Cookies](https://www.w3.org/TR/webdriver2/#cookies)
+impl Client {
+    /// Get all cookies associated with the current document.
+    ///
+    /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver2/#get-all-cookies) of the
+    /// WebDriver standard.
+    pub async fn get_all_cookies(&mut self) -> Result<Vec<Json>, error::CmdError> {
+        let resp = self.issue(WebDriverCommand::GetCookies).await?;
+        let raw_cookies = resp.as_array();
+
+        if raw_cookies.is_none() {
+            // We are expecting a JSON array of cookies at the top-level
+            let err =
+                error::CmdError::UnexpectedJson("expected a JSON array of cookie objects".to_string());
+            return Err(err);
+        }
+
+        let cookies = raw_cookies.unwrap().clone();
+
+        Ok(cookies)
+    }
+
+    /// Get a single named cookie associated with the current document.
+    ///
+    /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver2/#get-named-cookie) of the
+    /// WebDriver standard.
+    pub async fn get_named_cookie(&mut self, name: String) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::GetNamedCookie(name)).await
+    }
+
+    /// Add a single cookie to the current document.
+    ///
+    /// See [16.3 Add Cookie](https://www.w3.org/TR/webdriver2/#add-cookie) of the
+    /// WebDriver standard.
+    pub async fn add_cookie(
+        &mut self,
+        name: String,
+        value: String,
+        path: Option<String>,
+        domain: Option<String>,
+        secure: bool,
+        http_only: bool,
+        expiry: Option<u64>,
+        same_site: Option<String>,
+    ) -> Result<Json, error::CmdError> {
+        let params = webdriver::command::AddCookieParameters {
+            name,
+            value,
+            path,
+            domain,
+            secure,
+            httpOnly: http_only,
+            expiry: expiry.map(|v| webdriver::common::Date(v)),
+            sameSite: same_site,
+        };
+
+        self.issue(WebDriverCommand::AddCookie(params)).await
+    }
+
+    /// Delete a single cookie from the current document.
+    ///
+    /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver2/#delete-cookie) of the
+    /// WebDriver standard.
+    pub async fn delete_cookie(&mut self, name: String) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::DeleteCookie(name)).await
+    }
+
+    /// Delete all cookies from the current document.
+    ///
+    /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver2/#delete-all-cookies) of the
+    /// WebDriver standard.
+    pub async fn delete_all_cookies(&mut self) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::DeleteCookies).await
     }
 }
 

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,0 +1,150 @@
+use serde_json::Value as Json;
+use webdriver::command::WebDriverCommand;
+
+use crate::client::Client;
+use crate::error;
+
+/// Key names for cookie fields used by WebDriver JSON.
+const COOKIE_NAME: &str = "name";
+const COOKIE_VALUE: &str = "value";
+const COOKIE_PATH: &str = "path";
+const COOKIE_DOMAIN: &str = "domain";
+const COOKIE_SECURE: &str = "secure";
+const COOKIE_HTTP_ONLY: &str = "httpOnly";
+const COOKIE_EXPIRY: &str = "expiry";
+
+/// Build a `cookie::Cookie` from raw JSON.
+fn json_to_cookie(raw_cookie: &serde_json::Map<String, Json>) -> cookie::Cookie<'static> {
+    // Required keys
+    let name = raw_cookie.get(COOKIE_NAME).and_then(|v| v.as_str()).unwrap().to_string();
+    let value = raw_cookie.get(COOKIE_VALUE).and_then(|v| v.as_str()).unwrap().to_string();
+
+    let mut cookie = cookie::Cookie::new(name, value);
+
+    // Optional keys
+    let path = raw_cookie.get(COOKIE_PATH).and_then(|v| v.as_str()).map(String::from);
+    let domain = raw_cookie.get(COOKIE_DOMAIN).and_then(|v| v.as_str()).map(String::from);
+    let secure = raw_cookie.get(COOKIE_SECURE).and_then(|v| v.as_bool());
+    let http_only = raw_cookie.get(COOKIE_HTTP_ONLY).and_then(|v| v.as_bool());
+    let expiry = raw_cookie.get(COOKIE_EXPIRY).and_then(|v| v.as_u64());
+
+    if let Some(path) = path {
+        cookie.set_path(path);
+    }
+
+    if let Some(domain) = domain {
+        cookie.set_domain(domain);
+    }
+
+    if let Some(secure) = secure {
+        cookie.set_secure(secure);
+    }
+
+    if let Some(http_only) = http_only {
+        cookie.set_http_only(http_only);
+    }
+
+    if let Some(_expiry) = expiry {
+        todo!()
+    }
+
+    cookie
+}
+
+/// Serialize a `cookie::Cookie` to JSON.
+#[allow(unused)]
+fn cookie_to_json(cookie: &cookie::Cookie<'_>) -> Json {
+    let mut json = serde_json::json!(
+        { COOKIE_NAME: cookie.name(), COOKIE_VALUE: cookie.value() }
+    );
+
+    if let Some(path) = cookie.path() {
+        json[COOKIE_PATH] = Json::String(path.to_string());
+    }
+
+    if let Some(domain) = cookie.domain() {
+        json[COOKIE_DOMAIN] = Json::String(domain.to_string());
+    }
+
+    if let Some(secure) = cookie.secure() {
+        json[COOKIE_SECURE] = Json::Bool(secure);
+    }
+
+    if let Some(http_only) = cookie.http_only() {
+        json[COOKIE_HTTP_ONLY] = Json::Bool(http_only);
+    }
+
+    if let Some(_expiry) = cookie.expires() {
+        todo!()
+    }
+
+    json
+}
+
+/// [Cookies](https://www.w3.org/TR/webdriver2/#cookies)
+impl Client {
+    /// Get all cookies associated with the current document.
+    ///
+    /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver2/#get-all-cookies) of the
+    /// WebDriver standard.
+    pub async fn get_all_cookies(&mut self) -> Result<Vec<cookie::Cookie<'_>>, error::CmdError> {
+        let resp = self.issue(WebDriverCommand::GetCookies).await?;
+
+        let raw_cookies = resp.as_array();
+        if raw_cookies.is_none() {
+            let err =
+                error::CmdError::UnexpectedJson("expected a JSON array of cookie objects".to_string());
+            return Err(err);
+        }
+
+        let raw_cookies = raw_cookies.unwrap();
+        let mut cookies = Vec::new();
+
+        for raw_cookie in raw_cookies {
+            let raw_cookie = raw_cookie.as_object();
+            if raw_cookie.is_none() {
+                let err =
+                    error::CmdError::UnexpectedJson("expected a JSON object for cookie".to_string());
+                return Err(err);
+            }
+
+            cookies.push(json_to_cookie(raw_cookie.unwrap()));
+        }
+
+        Ok(cookies)
+    }
+
+    /// Get a single named cookie associated with the current document.
+    ///
+    /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver2/#get-named-cookie) of the
+    /// WebDriver standard.
+    pub async fn get_named_cookie(&mut self, name: &str) -> Result<cookie::Cookie<'_>, error::CmdError> {
+        self.issue(WebDriverCommand::GetNamedCookie(name.to_string())).await
+            .and_then(|raw_cookie| {
+                match raw_cookie.as_object() {
+                    None => {
+                        let err =
+                            error::CmdError::UnexpectedJson("expected a JSON object".to_string());
+                        Err(err)
+                    }
+                    Some(v) => Ok(json_to_cookie(v)),
+                }
+            })
+    }
+
+    /// Delete a single cookie from the current document.
+    ///
+    /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver2/#delete-cookie) of the
+    /// WebDriver standard.
+    pub async fn delete_cookie(&mut self, name: &str) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::DeleteCookie(name.to_string())).await
+    }
+
+    /// Delete all cookies from the current document.
+    ///
+    /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver2/#delete-all-cookies) of the
+    /// WebDriver standard.
+    pub async fn delete_all_cookies(&mut self) -> Result<Json, error::CmdError> {
+        self.issue(WebDriverCommand::DeleteCookies).await
+    }
+}

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,3 +1,4 @@
+//! Cookie-related functionality for WebDriver.
 use serde_json::Value as Json;
 use time::OffsetDateTime;
 use webdriver::command::WebDriverCommand;
@@ -5,7 +6,8 @@ use webdriver::command::WebDriverCommand;
 use crate::client::Client;
 use crate::error;
 
-type Cookie = cookie::Cookie<'static>;
+/// Type alias for a `cookie::Cookie`
+pub type Cookie<'a> = cookie::Cookie<'a>;
 
 /// Key names for cookie fields used by WebDriver JSON.
 const COOKIE_NAME: &str = "name";
@@ -17,7 +19,7 @@ const COOKIE_HTTP_ONLY: &str = "httpOnly";
 const COOKIE_EXPIRY: &str = "expiry";
 
 /// Build a `cookie::Cookie` from raw JSON.
-fn json_to_cookie(raw_cookie: &serde_json::Map<String, Json>) -> Cookie {
+fn json_to_cookie(raw_cookie: &serde_json::Map<String, Json>) -> Cookie<'static> {
     // Required keys
     let name = raw_cookie.get(COOKIE_NAME).and_then(|v| v.as_str()).unwrap().to_string();
     let value = raw_cookie.get(COOKIE_VALUE).and_then(|v| v.as_str()).unwrap().to_string();
@@ -92,7 +94,7 @@ impl Client {
     ///
     /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver1/#get-all-cookies) of the
     /// WebDriver standard.
-    pub async fn get_all_cookies(&mut self) -> Result<Vec<Cookie>, error::CmdError> {
+    pub async fn get_all_cookies(&mut self) -> Result<Vec<Cookie<'static>>, error::CmdError> {
         let resp = self.issue(WebDriverCommand::GetCookies).await?;
 
         let raw_cookies = resp.as_array();
@@ -123,7 +125,7 @@ impl Client {
     ///
     /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver1/#get-named-cookie) of the
     /// WebDriver standard.
-    pub async fn get_named_cookie(&mut self, name: &str) -> Result<Cookie, error::CmdError> {
+    pub async fn get_named_cookie(&mut self, name: &str) -> Result<Cookie<'static>, error::CmdError> {
         self.issue(WebDriverCommand::GetNamedCookie(name.to_string())).await
             .and_then(|raw_cookie| {
                 match raw_cookie.as_object() {

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -86,11 +86,11 @@ fn cookie_to_json(cookie: &cookie::Cookie<'_>) -> Json {
     raw_cookie
 }
 
-/// [Cookies](https://www.w3.org/TR/webdriver2/#cookies)
+/// [Cookies](https://www.w3.org/TR/webdriver1/#cookies)
 impl Client {
     /// Get all cookies associated with the current document.
     ///
-    /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver2/#get-all-cookies) of the
+    /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver1/#get-all-cookies) of the
     /// WebDriver standard.
     pub async fn get_all_cookies(&mut self) -> Result<Vec<Cookie>, error::CmdError> {
         let resp = self.issue(WebDriverCommand::GetCookies).await?;
@@ -121,7 +121,7 @@ impl Client {
 
     /// Get a single named cookie associated with the current document.
     ///
-    /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver2/#get-named-cookie) of the
+    /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver1/#get-named-cookie) of the
     /// WebDriver standard.
     pub async fn get_named_cookie(&mut self, name: &str) -> Result<Cookie, error::CmdError> {
         self.issue(WebDriverCommand::GetNamedCookie(name.to_string())).await
@@ -139,7 +139,7 @@ impl Client {
 
     /// Delete a single cookie from the current document.
     ///
-    /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver2/#delete-cookie) of the
+    /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver1/#delete-cookie) of the
     /// WebDriver standard.
     pub async fn delete_cookie(&mut self, name: &str) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DeleteCookie(name.to_string()))
@@ -149,7 +149,7 @@ impl Client {
 
     /// Delete all cookies from the current document.
     ///
-    /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver2/#delete-all-cookies) of the
+    /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver1/#delete-all-cookies) of the
     /// WebDriver standard.
     pub async fn delete_all_cookies(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DeleteCookies)

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,9 +104,6 @@ pub enum CmdError {
     /// The WebDriver server responded to a command with an invalid JSON response.
     Json(serde_json::Error),
 
-    /// Unexpected JSON response
-    UnexpectedJson(String),
-
     /// The WebDriver server produced a response that does not conform to the [W3C WebDriver
     /// specification][spec].
     ///
@@ -154,7 +151,6 @@ impl Error for CmdError {
             CmdError::Lost(..) => "webdriver connection lost",
             CmdError::NotJson(..) => "webdriver returned invalid response",
             CmdError::Json(..) => "webdriver returned incoherent response",
-            CmdError::UnexpectedJson(..) => "webdriver returned unexpected JSON response",
             CmdError::NotW3C(..) => "webdriver returned non-conforming response",
             CmdError::InvalidArgument(..) => "invalid argument provided",
             CmdError::ImageDecodeError(..) => "error decoding image",
@@ -172,7 +168,6 @@ impl Error for CmdError {
             CmdError::Json(ref e) => Some(e),
             CmdError::ImageDecodeError(ref e) => Some(e),
             CmdError::NotJson(_)
-            | CmdError::UnexpectedJson(_)
             | CmdError::NotW3C(_)
             | CmdError::InvalidArgument(..) => None,
         }
@@ -192,7 +187,6 @@ impl fmt::Display for CmdError {
             CmdError::Lost(ref e) => write!(f, "{}", e),
             CmdError::NotJson(ref e) => write!(f, "{}", e),
             CmdError::Json(ref e) => write!(f, "{}", e),
-            CmdError::UnexpectedJson(ref e) => write!(f, "{}", e),
             CmdError::NotW3C(ref e) => write!(f, "{:?}", e),
             CmdError::ImageDecodeError(ref e) => write!(f, "{:?}", e),
             CmdError::InvalidArgument(ref arg, ref msg) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub enum CmdError {
     /// The WebDriver server responded to a command with an invalid JSON response.
     Json(serde_json::Error),
 
+    /// Unexpected JSON response
+    UnexpectedJson(String),
+
     /// The WebDriver server produced a response that does not conform to the [W3C WebDriver
     /// specification][spec].
     ///
@@ -151,6 +154,7 @@ impl Error for CmdError {
             CmdError::Lost(..) => "webdriver connection lost",
             CmdError::NotJson(..) => "webdriver returned invalid response",
             CmdError::Json(..) => "webdriver returned incoherent response",
+            CmdError::UnexpectedJson(..) => "webdriver returned unexpected JSON response",
             CmdError::NotW3C(..) => "webdriver returned non-conforming response",
             CmdError::InvalidArgument(..) => "invalid argument provided",
             CmdError::ImageDecodeError(..) => "error decoding image",
@@ -167,7 +171,10 @@ impl Error for CmdError {
             CmdError::Lost(ref e) => Some(e),
             CmdError::Json(ref e) => Some(e),
             CmdError::ImageDecodeError(ref e) => Some(e),
-            CmdError::NotJson(_) | CmdError::NotW3C(_) | CmdError::InvalidArgument(..) => None,
+            CmdError::NotJson(_)
+            | CmdError::UnexpectedJson(_)
+            | CmdError::NotW3C(_)
+            | CmdError::InvalidArgument(..) => None,
         }
     }
 }
@@ -185,6 +192,7 @@ impl fmt::Display for CmdError {
             CmdError::Lost(ref e) => write!(f, "{}", e),
             CmdError::NotJson(ref e) => write!(f, "{}", e),
             CmdError::Json(ref e) => write!(f, "{}", e),
+            CmdError::UnexpectedJson(ref e) => write!(f, "{}", e),
             CmdError::NotW3C(ref e) => write!(f, "{:?}", e),
             CmdError::ImageDecodeError(ref e) => write!(f, "{:?}", e),
             CmdError::InvalidArgument(ref arg, ref msg) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,4 +295,4 @@ mod client;
 pub use client::Client;
 
 pub mod elements;
-mod cookies;
+pub mod cookies;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,3 +295,4 @@ mod client;
 pub use client::Client;
 
 pub mod elements;
+mod cookies;

--- a/src/session.rs
+++ b/src/session.rs
@@ -577,6 +577,10 @@ where
                 body = Some(serde_json::to_string(loc).unwrap());
                 method = Method::POST;
             }
+            WebDriverCommand::DeleteCookie(_)
+            | WebDriverCommand::DeleteCookies => {
+                method = Method::DELETE;
+            }
             WebDriverCommand::ExecuteScript(ref script) => {
                 body = Some(serde_json::to_string(script).unwrap());
                 method = Method::POST;

--- a/src/session.rs
+++ b/src/session.rs
@@ -464,7 +464,13 @@ where
             WebDriverCommand::GetPageSource => base.join("source"),
             WebDriverCommand::FindElement(..) => base.join("element"),
             WebDriverCommand::FindElements(..) => base.join("elements"),
-            WebDriverCommand::GetCookies => base.join("cookie"),
+            WebDriverCommand::GetCookies
+            | WebDriverCommand::AddCookie(_)
+            | WebDriverCommand::DeleteCookies => base.join("cookie"),
+            WebDriverCommand::GetNamedCookie(ref name)
+            | WebDriverCommand::DeleteCookie(ref name) => {
+                base.join(&format!("cookie/{}", name))
+            }
             WebDriverCommand::ExecuteScript(..) if self.is_legacy => base.join("execute"),
             WebDriverCommand::ExecuteScript(..) => base.join("execute/sync"),
             WebDriverCommand::ExecuteAsyncScript(..) => base.join("execute/async"),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -28,6 +28,17 @@ pub fn make_capabilities(s: &str) -> map::Map<String, serde_json::Value> {
             let mut caps = serde_json::map::Map::new();
             let opts = serde_json::json!({
                 "args": ["--headless", "--disable-gpu", "--no-sandbox", "--disable-dev-shm-usage"],
+                "binary":
+                    if std::path::Path::new("/usr/bin/chromium-browser").exists() {
+                        // on Ubuntu, it's called chromium-browser
+                        "/usr/bin/chromium-browser"
+                    } else if std::path::Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome").exists() {
+                        // macOS
+                        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+                    } else {
+                        // elsewhere, it's just called chromium
+                        "/usr/bin/chromium"
+                    }
             });
             caps.insert("goog:chromeOptions".to_string(), opts.clone());
             caps

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -28,17 +28,6 @@ pub fn make_capabilities(s: &str) -> map::Map<String, serde_json::Value> {
             let mut caps = serde_json::map::Map::new();
             let opts = serde_json::json!({
                 "args": ["--headless", "--disable-gpu", "--no-sandbox", "--disable-dev-shm-usage"],
-                "binary":
-                    if std::path::Path::new("/usr/bin/chromium-browser").exists() {
-                        // on Ubuntu, it's called chromium-browser
-                        "/usr/bin/chromium-browser"
-                    } else if std::path::Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome").exists() {
-                        // macOS
-                        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-                    } else {
-                        // elsewhere, it's just called chromium
-                        "/usr/bin/chromium"
-                    }
             });
             caps.insert("goog:chromeOptions".to_string(), opts.clone());
             caps

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -256,30 +256,16 @@ async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> 
     c.close().await
 }
 
-/// Simple test to verify that cookie handling works
+// Verifies that basic cookie handling works
 async fn handle_cookies_test(mut c: Client) -> Result<(), error::CmdError> {
-    c.goto("https://en.wikipedia.org/").await?;
+    c.goto("https://google.com/").await?;
 
     let cookies = c.get_all_cookies().await?;
     assert!(cookies.len() > 0);
 
-    let (c1_name, c1_value) = ("fantoccini123", "test123");
-
-    c.add_cookie(
-        c1_name.into(),
-        c1_value.into(),
-        None,
-        None,
-        false,
-        false,
-        None,
-        None
-    ).await?;
-
-    // TODO: get this working
-    let cookie = c.get_named_cookie(c1_name.into()).await?;
-    let value = cookie.as_object().unwrap().get("value").unwrap().as_str().unwrap();
-    assert_eq!(value, c1_value);
+    c.delete_all_cookies().await?;
+    let cookies = c.get_all_cookies().await?;
+    assert!(cookies.len() == 0);
 
     c.close().await
 }
@@ -360,7 +346,7 @@ mod chrome {
 
     #[test]
     fn it_handles_cookies() {
-        tester!(handle_cookies_test, "firefox");
+        tester!(handle_cookies_test, "chrome");
     }
 }
 

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -344,6 +344,7 @@ mod chrome {
         tester!(wait_for_navigation_test, "chrome");
     }
 
+    #[serial]
     #[test]
     fn it_handles_cookies() {
         tester!(handle_cookies_test, "chrome");
@@ -431,6 +432,7 @@ mod firefox {
         tester!(wait_for_navigation_test, "firefox");
     }
 
+    #[serial]
     #[test]
     fn it_handles_cookies() {
         tester!(handle_cookies_test, "firefox");

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -263,6 +263,16 @@ async fn handle_cookies_test(mut c: Client) -> Result<(), error::CmdError> {
     let cookies = c.get_all_cookies().await?;
     assert!(cookies.len() > 0);
 
+    let first_cookie = &cookies[0];
+    assert_eq!(
+        c.get_named_cookie(first_cookie.name()).await?.value(),
+        first_cookie.value()
+    );
+
+    // Delete a cookie and make sure it's gone
+    c.delete_cookie(first_cookie.name()).await?;
+    assert!(c.get_named_cookie(first_cookie.name()).await.is_err());
+
     c.delete_all_cookies().await?;
     let cookies = c.get_all_cookies().await?;
     assert!(cookies.len() == 0);

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -256,6 +256,34 @@ async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> 
     c.close().await
 }
 
+/// Simple test to verify that cookie handling works
+async fn handle_cookies_test(mut c: Client) -> Result<(), error::CmdError> {
+    c.goto("https://en.wikipedia.org/").await?;
+
+    let cookies = c.get_all_cookies().await?;
+    assert!(cookies.len() > 0);
+
+    let (c1_name, c1_value) = ("fantoccini123", "test123");
+
+    c.add_cookie(
+        c1_name.into(),
+        c1_value.into(),
+        None,
+        None,
+        false,
+        false,
+        None,
+        None
+    ).await?;
+
+    // TODO: get this working
+    let cookie = c.get_named_cookie(c1_name.into()).await?;
+    let value = cookie.as_object().unwrap().get("value").unwrap().as_str().unwrap();
+    assert_eq!(value, c1_value);
+
+    c.close().await
+}
+
 mod chrome {
     use super::*;
 
@@ -328,6 +356,11 @@ mod chrome {
     #[test]
     fn it_waits_for_navigation() {
         tester!(wait_for_navigation_test, "chrome");
+    }
+
+    #[test]
+    fn it_handles_cookies() {
+        tester!(handle_cookies_test, "firefox");
     }
 }
 
@@ -410,5 +443,10 @@ mod firefox {
     #[test]
     fn it_waits_for_navigation() {
         tester!(wait_for_navigation_test, "firefox");
+    }
+
+    #[test]
+    fn it_handles_cookies() {
+        tester!(handle_cookies_test, "firefox");
     }
 }


### PR DESCRIPTION
## Overview

This PR adds support for the cookie operations defined in [16. Cookies](https://www.w3.org/TR/webdriver1/#cookies) in the WebDriver spec. In particular, I've implemented the following operations:

* Get All Cookies
* Get Named Cookie
* Delete Cookie
* Delete All Cookies

The last operation, "Add Cookie", requires support from the `webdriver` crate.  The primary issue is that the `AddCookieParameters` struct does not implement `Serialize`, which means that we can't build the POST request on our side.  I'll be trying to get in touch with the geckodriver folks to see if this can be changed on their end.

## Changes

* Added a new module, `cookies.rs`.  This module contains the cookie-related `Client` methods as well as a few functions for converting between raw JSON (from WebDriver) and `cookie::Cookie` for the APIs.
* Added a simple integration testcase that triggers the `get_all_cookies` and `delete_all_cookies` operations.
* Removed the `binary` flag/arg when creating the WebDriver test client.  Both `chromedriver` and `geckodriver` are able to detect the path to the browser binary automatically on Windows and Linux.

Closes #59.