### PR TITLE
Basic User Prompt implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,5 +294,6 @@ impl<'a> From<Locator<'a>> for webdriver::command::LocatorParameters {
 mod client;
 pub use client::Client;
 
-pub mod elements;
 pub mod cookies;
+pub mod elements;
+pub mod user_prompts;

--- a/src/session.rs
+++ b/src/session.rs
@@ -468,9 +468,7 @@ where
             | WebDriverCommand::AddCookie(_)
             | WebDriverCommand::DeleteCookies => base.join("cookie"),
             WebDriverCommand::GetNamedCookie(ref name)
-            | WebDriverCommand::DeleteCookie(ref name) => {
-                base.join(&format!("cookie/{}", name))
-            }
+            | WebDriverCommand::DeleteCookie(ref name) => base.join(&format!("cookie/{}", name)),
             WebDriverCommand::ExecuteScript(..) if self.is_legacy => base.join("execute"),
             WebDriverCommand::ExecuteScript(..) => base.join("execute/sync"),
             WebDriverCommand::ExecuteAsyncScript(..) => base.join("execute/async"),
@@ -508,6 +506,8 @@ where
             WebDriverCommand::SwitchToWindow(..) => base.join("window"),
             WebDriverCommand::CloseWindow => base.join("window"),
             WebDriverCommand::GetActiveElement => base.join("element/active"),
+            WebDriverCommand::DismissAlert => base.join("alert/dismiss"),
+            WebDriverCommand::AcceptAlert => base.join("alert/accept"),
             _ => unimplemented!(),
         }
     }
@@ -577,8 +577,7 @@ where
                 body = Some(serde_json::to_string(loc).unwrap());
                 method = Method::POST;
             }
-            WebDriverCommand::DeleteCookie(_)
-            | WebDriverCommand::DeleteCookies => {
+            WebDriverCommand::DeleteCookie(_) | WebDriverCommand::DeleteCookies => {
                 method = Method::DELETE;
             }
             WebDriverCommand::ExecuteScript(ref script) => {
@@ -622,6 +621,10 @@ where
             }
             WebDriverCommand::CloseWindow => {
                 method = Method::DELETE;
+            }
+            WebDriverCommand::AcceptAlert | WebDriverCommand::DismissAlert => {
+                body = Some("{}".to_string());
+                method = Method::POST;
             }
             _ => {}
         }

--- a/src/user_prompts.rs
+++ b/src/user_prompts.rs
@@ -12,10 +12,10 @@ use crate::Client;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum PromptAction {
-    /// `Accept` is equivalent to a user clicking the `OK` button in the prompt.
+    /// `Accept` is equivalent to a user clicking the _OK_ button in the prompt.
     Accept,
-    /// `Dismiss` is equivalent to a user clicking the `Cancel` or `OK` button in the prompt,
-    /// whichever is present and appears first.
+    /// `Dismiss` is equivalent to a user clicking the _Cancel_ or _OK_ button in the prompt,
+    /// whichever is present on the prompt, in that order.
     Dismiss,
 }
 

--- a/src/user_prompts.rs
+++ b/src/user_prompts.rs
@@ -13,7 +13,7 @@ use crate::Client;
 pub enum UserPrompt {
     /// `Accept` is equivalent to a user clicking the `OK` button in the prompt.
     Accept,
-    /// `Accept` is equivalent to a user clicking the `Cancel` or `OK` button in the prompt,
+    /// `Dismiss` is equivalent to a user clicking the `Cancel` or `OK` button in the prompt,
     /// whichever is present and appears first.
     Dismiss,
 }

--- a/src/user_prompts.rs
+++ b/src/user_prompts.rs
@@ -7,10 +7,11 @@ use webdriver::command::WebDriverCommand;
 use crate::error;
 use crate::Client;
 
-/// `UserPrompt` enumerates the different ways a `Client` can respond to a user prompt, or alert in
-/// the browser window.
+/// `PromptAction` enumerates the different actions a `Client` can take in response to a user prompt
+/// or alert in the browser window.
 #[derive(Debug, Clone)]
-pub enum UserPrompt {
+#[non_exhaustive]
+pub enum PromptAction {
     /// `Accept` is equivalent to a user clicking the `OK` button in the prompt.
     Accept,
     /// `Dismiss` is equivalent to a user clicking the `Cancel` or `OK` button in the prompt,
@@ -20,14 +21,17 @@ pub enum UserPrompt {
 
 impl Client {
     /// Sends a response to the user prompt. For the different values you can provide, see
-    /// [`UserPrompt`].
+    /// [`PromptAction`].
     ///
     /// See [18. User Prompts](https://www.w3.org/TR/webdriver1/#user-prompts) of the WebDriver
     /// standard.
-    pub async fn handle_user_prompt(&mut self, prompt: &UserPrompt) -> Result<(), error::CmdError> {
-        let cmd = match prompt {
-            UserPrompt::Accept => WebDriverCommand::AcceptAlert,
-            UserPrompt::Dismiss => WebDriverCommand::DismissAlert,
+    pub async fn handle_user_prompt(
+        &mut self,
+        action: &PromptAction,
+    ) -> Result<(), error::CmdError> {
+        let cmd = match action {
+            PromptAction::Accept => WebDriverCommand::AcceptAlert,
+            PromptAction::Dismiss => WebDriverCommand::DismissAlert,
         };
         self.issue(cmd).await?;
         Ok(())

--- a/src/user_prompts.rs
+++ b/src/user_prompts.rs
@@ -20,7 +20,7 @@ pub enum UserPrompt {
 
 impl Client {
     /// Sends a response to the user prompt. For the different values you can provide, see
-    /// [UserPrompt](/UserPrompt).
+    /// [`UserPrompt`].
     ///
     /// See [18. User Prompts](https://www.w3.org/TR/webdriver1/#user-prompts) of the WebDriver
     /// standard.

--- a/src/user_prompts.rs
+++ b/src/user_prompts.rs
@@ -1,0 +1,35 @@
+//! User prompt related functionality for WebDriver.
+//!
+//! See [18. User Prompts](https://www.w3.org/TR/webdriver1/#user-prompts) of the WebDriver
+//! standard.
+use webdriver::command::WebDriverCommand;
+
+use crate::error;
+use crate::Client;
+
+/// `UserPrompt` enumerates the different ways a `Client` can respond to a user prompt, or alert in
+/// the browser window.
+#[derive(Debug, Clone)]
+pub enum UserPrompt {
+    /// `Accept` is equivalent to a user clicking the `OK` button in the prompt.
+    Accept,
+    /// `Accept` is equivalent to a user clicking the `Cancel` or `OK` button in the prompt,
+    /// whichever is present and appears first.
+    Dismiss,
+}
+
+impl Client {
+    /// Sends a response to the user prompt. For the different values you can provide, see
+    /// [UserPrompt](/UserPrompt).
+    ///
+    /// See [18. User Prompts](https://www.w3.org/TR/webdriver1/#user-prompts) of the WebDriver
+    /// standard.
+    pub async fn handle_user_prompt(&mut self, prompt: &UserPrompt) -> Result<(), error::CmdError> {
+        let cmd = match prompt {
+            UserPrompt::Accept => WebDriverCommand::AcceptAlert,
+            UserPrompt::Dismiss => WebDriverCommand::DismissAlert,
+        };
+        self.issue(cmd).await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Provides an implementation for handling user prompts as defined here: https://www.w3.org/TR/webdriver1/#user-prompts

This only includes responding with `Accept` and `Dismiss`.