### PR TITLE
Implement "wait for" functions with a timeout

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Click the "Get Started" button.
     let button = client
         .wait()
-        .on_element(Locator::Css(
+        .on(Locator::Css(
             r#"a.button-download[href="/learn/get-started"]"#,
         ))
         .await?;
@@ -47,21 +47,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Click the "Try Rust Without Installing" button (using XPath this time).
     let button = r#"//a[@class="button button-secondary" and @href="https://play.rust-lang.org/"]"#;
-    let button = client.wait().on_element(Locator::XPath(button)).await?;
+    let button = client.wait().on(Locator::XPath(button)).await?;
     button.click().await?;
 
     // Find the big textarea.
-    let mut code_area = client
-        .wait()
-        .on_element(Locator::Css(".ace_text-input"))
-        .await?;
+    let mut code_area = client.wait().on(Locator::Css(".ace_text-input")).await?;
 
     // And write in some code.
     code_area.send_keys("// Hello from Fantoccini\n").await?;
 
     // Now, let's run it!
     let button = r#"//div[@class="segmented-button"]/button[1]"#;
-    let button = client.wait().on_element(Locator::XPath(button)).await?;
+    let button = client.wait().on(Locator::XPath(button)).await?;
     button.click().await?;
 
     // Let the user marvel at what we achieved.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -36,34 +36,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Go to the Rust website.
     client.goto("https://www.rust-lang.org/").await?;
 
-    // This sleep is just used to make the browser's actions visible.
-    sleep(Duration::from_millis(1000)).await;
-
     // Click the "Get Started" button.
     let button = client
-        .find(Locator::Css(
+        .wait()
+        .on_element(Locator::Css(
             r#"a.button-download[href="/learn/get-started"]"#,
         ))
         .await?;
     button.click().await?;
-    sleep(Duration::from_millis(1000)).await;
 
     // Click the "Try Rust Without Installing" button (using XPath this time).
     let button = r#"//a[@class="button button-secondary" and @href="https://play.rust-lang.org/"]"#;
-    let button = client.find(Locator::XPath(button)).await?;
+    let button = client.wait().on_element(Locator::XPath(button)).await?;
     button.click().await?;
-    sleep(Duration::from_millis(1000)).await;
 
     // Find the big textarea.
-    let mut code_area = client.find(Locator::Css(".ace_text-input")).await?;
+    let mut code_area = client
+        .wait()
+        .on_element(Locator::Css(".ace_text-input"))
+        .await?;
 
     // And write in some code.
     code_area.send_keys("// Hello from Fantoccini\n").await?;
-    sleep(Duration::from_millis(1000)).await;
 
     // Now, let's run it!
     let button = r#"//div[@class="segmented-button"]/button[1]"#;
-    let button = client.find(Locator::XPath(button)).await?;
+    let button = client.wait().on_element(Locator::XPath(button)).await?;
     button.click().await?;
 
     // Let the user marvel at what we achieved.

--- a/examples/wait.rs
+++ b/examples/wait.rs
@@ -1,0 +1,83 @@
+use fantoccini::elements::Element;
+use fantoccini::wait::{Condition, Predicate};
+use fantoccini::{ClientBuilder, Locator};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to webdriver instance that is listening on port 4444
+    let mut client = ClientBuilder::native()
+        .connect("http://localhost:4444")
+        .await?;
+
+    // Go to the Rust website.
+    client.goto("https://www.rust-lang.org/").await?;
+
+    // You can wait on anything that implements `WaitCondition`
+
+    // Wait for a URL
+    let _: () = client
+        .wait()
+        .on(url::Url::parse("https://www.rust-lang.org/")?)
+        .await?;
+
+    // Wait for a locator, and get back the element.
+    let _: Element = client
+        .wait()
+        .on(Locator::Css(
+            r#"a.button-download[href="/learn/get-started"]"#,
+        ))
+        .await?;
+
+    // By default it will time-out after 30 seconds and check every 250 milliseconds.
+    // However, you can change this.
+
+    let _: Element = client
+        .wait()
+        .at_most(Duration::from_secs(5))
+        .every(Duration::from_millis(100))
+        .on(Locator::Css(
+            r#"a.button-download[href="/learn/get-started"]"#,
+        ))
+        .await?;
+
+    // You can also use closures for more custom checks. However, in order to deal with
+    // async traits and lifetimes, they need to be wrapped in a newtype in order to implement
+    // the WaitCondition trait.
+
+    // Wait for a condition (returning a value)
+    let _: String = client
+        .wait()
+        .on(Condition(|client| {
+            Box::pin(async move { Ok(client.get_ua().await?) })
+        }))
+        .await?;
+
+    // Wait for a condition, using a dedicated method to avoid using the newtype.
+    let _: String = client
+        .wait()
+        .on_condition(|client| Box::pin(async move { Ok(client.get_ua().await?) }))
+        .await?;
+
+    // Instead of a condition, returning a value, you can also wait for a boolean outcome.
+
+    // Wait for a predicate (true or false)
+    let _: () = client
+        .wait()
+        .on(Predicate(|client| {
+            Box::pin(async move { Ok(client.source().await?.contains("Rust")) })
+        }))
+        .await?;
+
+    // Wait for a predicate (true or false), using a dedicated method.
+    let _: () = client
+        .wait()
+        .on_predicate(|client| Box::pin(async move { Ok(client.source().await?.contains("Rust")) }))
+        .await?;
+
+    // Then close the browser window.
+    client.close().await?;
+
+    // done
+    Ok(())
+}

--- a/examples/wait.rs
+++ b/examples/wait.rs
@@ -13,6 +13,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Go to the Rust website.
     client.goto("https://www.rust-lang.org/").await?;
 
+    // The explicit return types in following code is just to illustrate the type returned.
+    // You can omit them in your code.
+
     // You can wait on anything that implements `WaitCondition`
 
     // Wait for a URL
@@ -56,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Wait for a condition, using a dedicated method to avoid using the newtype.
     let _: String = client
         .wait()
-        .on_condition(|client| Box::pin(async move { Ok(client.get_ua().await?) }))
+        .until_some(|client| Box::pin(async move { Ok(client.get_ua().await?) }))
         .await?;
 
     // Instead of a condition, returning a value, you can also wait for a boolean outcome.
@@ -72,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Wait for a predicate (true or false), using a dedicated method.
     let _: () = client
         .wait()
-        .on_predicate(|client| Box::pin(async move { Ok(client.source().await?.contains("Rust")) }))
+        .until(|client| Box::pin(async move { Ok(client.source().await?.contains("Rust")) }))
         .await?;
 
     // Then close the browser window.

--- a/src/client.rs
+++ b/src/client.rs
@@ -671,13 +671,7 @@ impl Client {
         note = "This method might block forever. Please use client.wait().on(locator) instead. You can still wait forever using: client.wait().forever().on(locator)"
     )]
     pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
-        loop {
-            match self.wait().forever().on(search).await {
-                Ok(ele) => break Ok(ele),
-                Err(error::CmdError::WaitTimeout) => continue,
-                Err(err) => break Err(err),
-            }
-        }
+        self.wait().forever().on(search).await
     }
 
     /// Wait for the page to navigate to a new URL before proceeding.

--- a/src/client.rs
+++ b/src/client.rs
@@ -820,7 +820,29 @@ impl Client {
 
 /// Allow to wait for conditions.
 impl Client {
-    /// Start a new wait
+    /// Starting building a new wait operation. This can be used to wait for a certain condition, by
+    /// periodically checking the state and optionally returning a value:
+    ///
+    /// ```no_run
+    /// # use fantoccini::{ClientBuilder, Locator};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), fantoccini::error::CmdError> {
+    /// # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
+    /// # let mut client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # #[cfg(feature = "rustls-tls")]
+    /// # let mut client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
+    /// # let mut client: fantoccini::Client = unreachable!("no tls provider available");
+    /// // -- snip wrapper code --
+    /// let button = client.wait().on(Locator::Css(
+    ///     r#"a.button-download[href="/learn/get-started"]"#,
+    /// )).await?;
+    /// // -- snip wrapper code --
+    /// # client.close().await
+    /// # }
+    /// ```
+    ///
+    /// Also see: [`crate::wait`].
     pub fn wait(&mut self) -> Wait<'_> {
         Wait::new(self)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use crate::elements::{Element, Form};
 use crate::session::{Cmd, Session, Task};
+use crate::wait::Wait;
 use crate::{error, Locator};
 use hyper::{client::connect, Method};
 use serde_json::Value as Json;
@@ -814,6 +815,14 @@ impl Client {
             Ok(Err(e)) => Err(e.into()),
             Err(e) => unreachable!("Session ended prematurely: {:?}", e),
         }
+    }
+}
+
+/// Allow to wait for conditions.
+impl Client {
+    /// Start a new wait
+    pub fn wait(&mut self) -> Wait<'_> {
+        Wait::new(self)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,9 @@ pub enum CmdError {
 
     /// Could not decode a base64 image
     ImageDecodeError(::base64::DecodeError),
+
+    /// Timeout of a wait condition
+    WaitTimeout,
 }
 
 impl CmdError {
@@ -154,6 +157,7 @@ impl Error for CmdError {
             CmdError::NotW3C(..) => "webdriver returned non-conforming response",
             CmdError::InvalidArgument(..) => "invalid argument provided",
             CmdError::ImageDecodeError(..) => "error decoding image",
+            CmdError::WaitTimeout => "timeout waiting on condition",
         }
     }
 
@@ -169,7 +173,8 @@ impl Error for CmdError {
             CmdError::ImageDecodeError(ref e) => Some(e),
             CmdError::NotJson(_)
             | CmdError::NotW3C(_)
-            | CmdError::InvalidArgument(..) => None,
+            | CmdError::InvalidArgument(..)
+            | CmdError::WaitTimeout => None,
         }
     }
 }
@@ -192,6 +197,7 @@ impl fmt::Display for CmdError {
             CmdError::InvalidArgument(ref arg, ref msg) => {
                 write!(f, "Invalid argument `{}`: {}", arg, msg)
             }
+            CmdError::WaitTimeout => Ok(()),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,7 +121,11 @@ pub enum CmdError {
     /// Could not decode a base64 image
     ImageDecodeError(::base64::DecodeError),
 
-    /// Timeout of a wait condition
+    /// Timeout of a wait condition.
+    ///
+    /// When waiting for a for a condition using [`Client::wait`], any of the consuming methods,
+    /// waiting on some condition, may return this error, indicating that the timeout waiting
+    /// for the condition occurred.
     WaitTimeout,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,8 +294,8 @@ impl<'a> From<Locator<'a>> for webdriver::command::LocatorParameters {
 mod client;
 pub use client::Client;
 
-pub mod elements;
 pub mod cookies;
+pub mod elements;
 
 /// Allow to wait for things
 pub mod wait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,3 +296,6 @@ pub use client::Client;
 
 pub mod elements;
 pub mod cookies;
+
+/// Allow to wait for things
+pub mod wait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,5 +297,5 @@ pub use client::Client;
 pub mod cookies;
 pub mod elements;
 
-/// Allow to wait for things
+/// Allow to wait for conditions.
 pub mod wait;

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -119,7 +119,7 @@ impl<'c> Wait<'c> {
     }
 
     /// Wait until a condition exists or a timeout is hit.
-    pub async fn on_condition<T, F>(self, f: F) -> Result<T, error::CmdError>
+    pub async fn until_some<T, F>(self, f: F) -> Result<T, error::CmdError>
     where
         F: for<'f> FnMut(
             &'f mut Client,

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -102,18 +102,6 @@ impl<'c> Wait<'c> {
     }
 }
 
-/// Allow creating a wait operation.
-pub trait CanWait {
-    /// Create a new wait operation.
-    fn wait(&mut self) -> Wait<'_>;
-}
-
-impl CanWait for Client {
-    fn wait(&mut self) -> Wait<'_> {
-        Wait::new(self)
-    }
-}
-
 /// An error that can occur when waiting.
 #[derive(Debug)]
 pub enum WaitError {

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -30,7 +30,7 @@ impl<'c> Wait<'c> {
     }
 
     /// Set the timeout until the operation should wait.
-    pub fn until(mut self, timeout: Duration) -> Self {
+    pub fn at_most(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,0 +1,155 @@
+use crate::{elements::Element, error, Client, Locator};
+use core::fmt;
+use futures_util::TryFutureExt;
+use std::{
+    error::Error,
+    future::Future,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_PERIOD: Duration = Duration::from_millis(250);
+
+/// Used for setting up a wait operation on the client.
+#[derive(Debug)]
+pub struct Wait<'c> {
+    client: &'c mut Client,
+    timeout: Option<Duration>,
+    period: Duration,
+}
+
+impl<'c> Wait<'c> {
+    /// Create a new wait operation from a client.
+    pub fn new(client: &'c mut Client) -> Self {
+        Self {
+            client,
+            timeout: Some(DEFAULT_TIMEOUT),
+            period: DEFAULT_PERIOD,
+        }
+    }
+
+    /// Set the timeout until the operation should wait.
+    pub fn until(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Wait forever.
+    pub fn forever(mut self) -> Self {
+        self.timeout = None;
+        self
+    }
+
+    /// Sets the period to delay checks.
+    pub fn every(mut self, period: Duration) -> Self {
+        self.period = period;
+        self
+    }
+
+    /// Wait until a condition exists or a timeout is hit.
+    pub async fn on<T, F>(self, mut f: F) -> Result<T, WaitError>
+    where
+        F: for<'f> FnMut(
+            &'f mut Client,
+        )
+            -> Pin<Box<dyn Future<Output = Result<Option<T>, error::CmdError>> + 'f>>,
+    {
+        let start = Instant::now();
+        loop {
+            match self.timeout {
+                Some(timeout) if start.elapsed() > timeout => break Err(WaitError::Timeout),
+                _ => {}
+            }
+            match f(self.client).await? {
+                Some(result) => break Ok(result),
+                None => {
+                    tokio::time::sleep(self.period).await;
+                }
+            };
+        }
+    }
+
+    /// Wait for an element.
+    pub async fn on_element(self, locator: Locator<'static>) -> Result<Element, WaitError> {
+        self.on(move |client| {
+            Box::pin(async move {
+                match client.find(locator).await {
+                    Ok(element) => Ok(Some(element)),
+                    Err(error::CmdError::NoSuchElement(_)) => Ok(None),
+                    Err(err) => Err(err),
+                }
+            })
+        })
+        .await
+    }
+
+    /// Wait for a predicate.
+    pub async fn on_predicate<F>(self, mut predicate: F) -> Result<(), WaitError>
+    where
+        F: for<'f> FnMut(
+            &'f mut Client,
+        )
+            -> Pin<Box<dyn Future<Output = Result<bool, error::CmdError>> + 'f>>,
+    {
+        self.on(|client| {
+            Box::pin(predicate(client).map_ok(|result| match result {
+                true => Some(()),
+                false => None,
+            }))
+        })
+        .await
+    }
+}
+
+/// Allow creating a wait operation.
+pub trait CanWait {
+    /// Create a new wait operation.
+    fn wait(&mut self) -> Wait<'_>;
+}
+
+impl CanWait for Client {
+    fn wait(&mut self) -> Wait<'_> {
+        Wait::new(self)
+    }
+}
+
+/// An error that can occur when waiting.
+#[derive(Debug)]
+pub enum WaitError {
+    /// The wait operation timed out
+    Timeout,
+    /// The client reported an error
+    Client(error::CmdError),
+}
+
+impl Error for WaitError {
+    fn description(&self) -> &str {
+        match self {
+            Self::Timeout => "timeout waiting on condition",
+            Self::Client(..) => "webdriver returned error",
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn Error> {
+        match self {
+            Self::Timeout => None,
+            Self::Client(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for WaitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "Timeout"),
+            Self::Client(cmd) => write!(f, "Client error: {}", cmd),
+        }
+    }
+}
+
+impl From<error::CmdError> for WaitError {
+    fn from(err: error::CmdError) -> Self {
+        Self::Client(err)
+    }
+}

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -45,8 +45,7 @@
 //! # Custom conditions
 //!
 //! You can implement custom conditions either by implementing the [`WaitCondition`] trait or by
-//! using closures. Due to lifetime and async trait difficulties, two newtypes and two dedicated
-//! functions exists to simplify the usage of closures. Also see: [`Closure`], [`Predicate`].
+//! using closures. If you just want a closure, use [`Wait::until`] and [`Wait::until_some`].
 
 use crate::error::CmdError;
 use crate::{elements::Element, error, Client, Locator};

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -13,7 +13,7 @@
 //!
 //! By default all wait operations will time-out after 30 seconds and will re-check every
 //! 250 milliseconds. You can configure this using the [`Wait::at_most`] and [`Wait::every`]
-//! methods.
+//! methods or use [`Wait::forver`] to wait indefinitely.
 //!
 //! Once configured, you can start waiting on some condition by using the [`Wait::on`] method. It
 //! accepts any type implementing the [`WaitCondition`] trait. For example:
@@ -47,11 +47,7 @@
 //! You can implement custom conditions either by implementing the [`WaitCondition`] trait or by
 //! using closures. Due to lifetime and async trait difficulties, two newtypes and two dedicated
 //! functions exists to simplify the usage of closures. Also see: [`Closure`], [`Predicate`].
-//!
-//! # Waiting indefinitely
-//!
-//! Previous `wait_*` functions on the client waited indefinitely. While this may case some
-//! problems, you can still get this behavior be calling the [`Wait::forver`] method.
+
 use crate::error::CmdError;
 use crate::{elements::Element, error, Client, Locator};
 use futures_util::TryFutureExt;

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -72,7 +72,7 @@ impl<'c> Wait<'c> {
     /// Create a new wait operation from a client.
     ///
     /// This only starts the process of building a new wait operation. Waiting, and checking, will
-    /// only begin once one of the `on_*` methods has been called.
+    /// only begin once one of the consuming methods has been called.
     ///
     /// ```no_run
     /// # use fantoccini::{ClientBuilder, Locator};
@@ -153,7 +153,7 @@ impl<'c> Wait<'c> {
     }
 
     /// Wait for a predicate.
-    pub async fn on_predicate<F>(self, predicate: F) -> Result<(), error::CmdError>
+    pub async fn until<F>(self, predicate: F) -> Result<(), error::CmdError>
     where
         F: for<'f> FnMut(
             &'f mut Client,

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -69,7 +69,7 @@ async fn send_keys_and_clear_input_inner(mut c: Client) -> Result<(), error::Cmd
     c.goto("https://www.wikipedia.org/").await?;
 
     // find search input element
-    let mut e = c.wait_for_find(Locator::Id("searchInput")).await?;
+    let mut e = c.wait().on(Locator::Id("searchInput")).await?;
     e.send_keys("foobar").await?;
     assert_eq!(
         e.prop("value")
@@ -222,6 +222,7 @@ async fn persist_inner(mut c: Client) -> Result<(), error::CmdError> {
 }
 
 async fn simple_wait_test(mut c: Client) -> Result<(), error::CmdError> {
+    #[allow(deprecated)]
     c.wait_for(move |_| {
         std::thread::sleep(Duration::from_secs(4));
         async move { Ok(true) }
@@ -241,6 +242,7 @@ async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> 
 
     c.goto(url.as_str()).await?;
 
+    #[allow(deprecated)]
     loop {
         let wait_for = c.wait_for_navigation(Some(url)).await;
         assert!(wait_for.is_ok());


### PR DESCRIPTION
This is first proposal for the following issues:

Fixes https://github.com/jonhoo/fantoccini/issues/81
Fixes https://github.com/jonhoo/fantoccini/issues/90
Fixes https://github.com/jonhoo/fantoccini/issues/27

I tried to:

* Avoid cloning the client
* Allow for future extensions on the wait parameters
* Provide a single non-opinionated "on" method
* Provide more opinionated function which make your live easier (on_element, on_predicate)

I didn't not async-trait, as it wasn't in the project already. Maybe that could help creating a better API.

One thing I wasn't able to achieve so far, is to provide a way directly pass in e.g. a `Locator` into the `on` method, and let it `Into` an appropriate function. I think that would be nice, but it also is a bit above my Rust future and lifetime knowledge.

It currently also lacks proper documentation.
