### PR TITLE
Upgrade hyper-rustls to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = [ "sync", "rt" ] }
 hyper = { version = "0.14", features = [ "stream", "client", "http1", "http2" ] }
 cookie = { version = "0.14", features = ["percent-encode"] }
 base64 = "0.13"
-hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { version = "0.23.0", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 mime = "0.3.9"
 http = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,13 @@ where
 impl ClientBuilder<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
     /// Build a [`Client`] that will connect using [Rustls](https://crates.io/crates/rustls).
     pub fn rustls() -> Self {
-        Self::new(hyper_rustls::HttpsConnector::with_native_roots())
+        Self::new(
+            hyper_rustls::HttpsConnectorBuilder::new()
+                .with_native_roots()
+                .https_or_http()
+                .enable_http1()
+                .build(),
+        )
     }
 }
 


### PR DESCRIPTION
Properly updates to hyper-rustls 0.23, as #141 and #139 give errors when trying to compile with it.

Closes #141 