### PR TITLE
Disable the hyper http2 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.25"
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "1", features = ["sync", "rt"] }
-hyper = { version = "0.14", features = ["stream", "client", "http1", "http2"] }
+hyper = { version = "0.14", features = ["stream", "client", "http1"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
 base64 = "0.13"
 hyper-rustls = { version = "0.23.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.25"
 futures-core = "0.3"
 futures-util = "0.3"
-tokio = { version = "1", features = ["sync", "rt"] }
+tokio = { version = "1", features = ["sync", "rt", "time"] }
 hyper = { version = "0.14", features = ["stream", "client", "http1"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
 base64 = "0.13"


### PR DESCRIPTION
Since you're going to release a minor version anyway I wouldn't mind having the ability to reduce `hyper`'s dependencies.

---

Makes the `http2` feature optional and enables it by default.