### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Disolved from https://github.com/jonhoo/fantoccini/pull/139#discussion_r765407794

This PR enables dependabot to auto-track dependencies updates.

Merge this only after #139 is merged, to omit redundant PRs from dependabot.