### PR TITLE
Implement remaining WebDriver commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,6 @@ println!("Wikipedia logo is {}b", pixels.len());
 
 For more examples, take a look at the `examples/` directory.
 
-[WebDriver protocol]: https://www.w3.org/TR/webdriver/
-[CSS selectors]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
-[powerful]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
-[operators]: https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
-[WebDriver compatible]: https://github.com/Fyrd/caniuse/issues/2757#issuecomment-304529217
-[`geckodriver`]: https://github.com/mozilla/geckodriver
-[`chromedriver`]: https://chromedriver.chromium.org/downloads
-
 # Contributing to fantoccini
 
 The following information applies only to developers interested in contributing
@@ -119,8 +111,16 @@ skip this section.
 
 ## How to run tests
 
-The tests assume that you have `chromedriver` and `geckodriver` already running on your system.
+The tests assume that you have [`chromedriver`] and [`geckodriver`] already running on your system.
 You can download them using the links above. Then run them from separate tabs in your terminal.
 They will stay running until terminated with Ctrl+C or until the terminal session is closed.
 
 Then run `cargo test` from this project directory.
+
+[WebDriver protocol]: https://www.w3.org/TR/webdriver/
+[CSS selectors]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
+[powerful]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
+[operators]: https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
+[WebDriver compatible]: https://github.com/Fyrd/caniuse/issues/2757#issuecomment-304529217
+[`geckodriver`]: https://github.com/mozilla/geckodriver
+[`chromedriver`]: https://chromedriver.chromium.org/downloads

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -2,11 +2,15 @@
 use crate::elements::Element;
 #[cfg(doc)]
 use crate::keys::Key;
+use crate::Client;
 use std::fmt::Debug;
 use std::time::Duration;
 use webdriver::actions as WDActions;
 
 /// An action not associated with an input device (i.e. pause).
+///
+/// See [17.4.1 General Actions](https://www.w3.org/TR/webdriver1/#general-actions) of the
+/// WebDriver standard.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum NullAction {
@@ -30,6 +34,9 @@ impl NullAction {
 }
 
 /// An action performed with a keyboard.
+///
+/// See [17.4.2 Keyboard Actions](https://www.w3.org/TR/webdriver1/#keyboard-actions) of the
+/// WebDriver standard.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum KeyAction {
@@ -74,8 +81,21 @@ impl KeyAction {
     }
 }
 
-/// An action performed with a pointer device. See `PointerActionType` for
-/// the availabledevice types.
+/// Left mouse button constant for use with `PointerAction`.
+pub const MOUSE_BUTTON_LEFT: u64 = 0;
+
+/// Middle mouse button constant for use with `PointerAction`.
+pub const MOUSE_BUTTON_MIDDLE: u64 = 1;
+
+/// Right mouse button constant for use with `PointerAction`.
+pub const MOUSE_BUTTON_RIGHT: u64 = 2;
+
+/// An action performed with a pointer device.
+///
+/// This can be a mouse, pen or touch device.
+///
+/// See [17.4.3 Pointer Actions](https://www.w3.org/TR/webdriver1/#pointer-actions) of the
+/// WebDriver standard.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum PointerAction {
@@ -101,11 +121,12 @@ pub enum PointerAction {
         /// - Right = 2
         button: u64,
     },
-    /// Pointer move action. Duration is specified in milliseconds (can be 0).
+    /// Pointer move action.
+    ///
     /// The x and y offsets are relative to the origin.
     Move {
-        /// The move duration, given in milliseconds.
-        duration: u64,
+        /// The move duration.
+        duration: Option<Duration>,
         /// The origin that the `x` and `y` coordinates are relative to.
         origin: PointerOrigin,
         /// `x` offset, in pixels.
@@ -134,31 +155,9 @@ impl PointerOrigin {
         match self {
             PointerOrigin::Viewport => WDActions::PointerOrigin::Viewport,
             PointerOrigin::Pointer => WDActions::PointerOrigin::Pointer,
-            PointerOrigin::WebElement(e) => {
-                WDActions::PointerOrigin::Element(webdriver::common::WebElement(e.element_id().0))
-            }
-        }
-    }
-}
-
-/// The type of pointer.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub enum PointerActionType {
-    /// A mouse pointer device.
-    Mouse,
-    /// A pen device.
-    Pen,
-    /// A touch device.
-    Touch,
-}
-
-impl PointerActionType {
-    fn into_wd_pointertype(self) -> WDActions::PointerType {
-        match self {
-            PointerActionType::Mouse => WDActions::PointerType::Mouse,
-            PointerActionType::Pen => WDActions::PointerType::Pen,
-            PointerActionType::Touch => WDActions::PointerType::Touch,
+            PointerOrigin::WebElement(e) => WDActions::PointerOrigin::Element(
+                webdriver::common::WebElement(e.element_id().into()),
+            ),
         }
     }
 }
@@ -184,7 +183,7 @@ impl PointerAction {
                 y,
             } => WDActions::PointerActionItem::Pointer(WDActions::PointerAction::Move(
                 WDActions::PointerMoveAction {
-                    duration: Some(duration),
+                    duration: duration.map(|x| x.as_millis() as u64),
                     origin: origin.into_wd_pointerorigin(),
                     x: Some(x),
                     y: Some(y),
@@ -197,739 +196,302 @@ impl PointerAction {
     }
 }
 
-/// A channel containing `Null` actions.
+/// A sequence containing `Null` actions.
 #[derive(Debug, Clone)]
-pub struct NullActionChannel {
-    /// An identifier to distinguish this channel from others. Choose a meaningful string.
-    /// May be useful for debugging.
+pub struct NullActions {
+    /// An identifier to distinguish this sequence from others.
+    ///
+    /// Choose a meaningful string as it may be useful for debugging.
     id: String,
-    /// The list of actions for this channel.
+    /// The list of actions for this sequence.
     actions: Vec<NullAction>,
 }
 
-impl NullActionChannel {
-    /// Create a new NullActionChannel.
+impl NullActions {
+    /// Create a new NullActions sequence.
     pub fn new(id: &str) -> Self {
         Self {
             id: id.to_string(),
             actions: Vec::new(),
         }
     }
+}
 
-    /// Add a pause action to this channel.
-    pub fn pause(&mut self, duration: Duration) -> &mut Self {
-        self.then(NullAction::Pause { duration })
-    }
-
-    /// Add the specified action to this channel.
-    pub fn then(&mut self, action: NullAction) -> &mut Self {
-        self.actions.push(action);
-        self
+impl From<NullActions> for ActionSequence {
+    fn from(na: NullActions) -> Self {
+        ActionSequence(WDActions::ActionSequence {
+            id: na.id,
+            actions: WDActions::ActionsType::Null {
+                actions: na.actions.into_iter().map(|x| x.into_item()).collect(),
+            },
+        })
     }
 }
 
-/// A channel containing `Key` actions.
+/// A sequence containing `Key` actions.
 #[derive(Debug, Clone)]
-pub struct KeyActionChannel {
-    /// An identifier to distinguish this channel from others. Choose a meaningful string.
-    /// May be useful for debugging.
+pub struct KeyActions {
+    /// An identifier to distinguish this sequence from others.
+    ///
+    /// Choose a meaningful string as it may be useful for debugging.
     id: String,
-    /// The list of actions for this channel.
+    /// The list of actions for this sequence.
     actions: Vec<KeyAction>,
 }
 
-impl KeyActionChannel {
-    /// Create a new Key channel.
+impl KeyActions {
+    /// Create a new KeyActions sequence.
     pub fn new(id: &str) -> Self {
         Self {
             id: id.to_string(),
             actions: Vec::new(),
         }
     }
+}
 
-    /// Add a pause action to this channel.
-    pub fn pause(&mut self, duration: Duration) -> &mut Self {
-        self.then(KeyAction::Pause { duration })
-    }
-
-    /// Add the specified action to this channel.
-    pub fn then(&mut self, action: KeyAction) -> &mut Self {
-        self.actions.push(action);
-        self
+impl From<KeyActions> for ActionSequence {
+    fn from(ka: KeyActions) -> Self {
+        ActionSequence(WDActions::ActionSequence {
+            id: ka.id,
+            actions: WDActions::ActionsType::Key {
+                actions: ka.actions.into_iter().map(|x| x.into_item()).collect(),
+            },
+        })
     }
 }
 
-/// A channel containing `Key` actions.
+/// A sequence containing `Pointer` actions for a mouse.
 #[derive(Debug, Clone)]
-pub struct PointerActionChannel {
-    /// An identifier to distinguish this channel from others. Choose a meaningful string.
-    /// May be useful for debugging.
+pub struct MouseActions {
+    /// An identifier to distinguish this sequence from others.
+    ///
+    /// Choose a meaningful string as it may be useful for debugging.
     id: String,
-    /// The pointer type. Can be `Mouse`, `Pen` or `Touch`.
-    pointer_type: PointerActionType,
-    /// The list of actions for this channel.
+    /// The list of actions for this sequence.
     actions: Vec<PointerAction>,
 }
 
-impl PointerActionChannel {
-    /// Create a new Pointer channel.
-    pub fn new(id: &str, pointer_type: PointerActionType) -> Self {
+impl MouseActions {
+    /// Create a new `MouseActions` sequence.
+    pub fn new(id: &str) -> Self {
         Self {
             id: id.to_string(),
-            pointer_type,
             actions: Vec::new(),
         }
     }
+}
 
-    /// Add a pause action to this channel.
-    pub fn pause(&mut self, duration: Duration) -> &mut Self {
-        self.then(PointerAction::Pause { duration })
+impl From<MouseActions> for ActionSequence {
+    fn from(ma: MouseActions) -> Self {
+        ActionSequence(WDActions::ActionSequence {
+            id: ma.id,
+            actions: WDActions::ActionsType::Pointer {
+                parameters: WDActions::PointerActionParameters {
+                    pointer_type: WDActions::PointerType::Mouse,
+                },
+                actions: ma.actions.into_iter().map(|x| x.into_item()).collect(),
+            },
+        })
+    }
+}
+
+/// A sequence containing `Pointer` actions for a pen device.
+#[derive(Debug, Clone)]
+pub struct PenActions {
+    /// An identifier to distinguish this sequence from others.
+    ///
+    /// Choose a meaningful string as it may be useful for debugging.
+    id: String,
+    /// The list of actions for this sequence.
+    actions: Vec<PointerAction>,
+}
+
+impl PenActions {
+    /// Create a new `PenActions` sequence.
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            actions: Vec::new(),
+        }
+    }
+}
+
+impl From<PenActions> for ActionSequence {
+    fn from(pa: PenActions) -> Self {
+        ActionSequence(WDActions::ActionSequence {
+            id: pa.id,
+            actions: WDActions::ActionsType::Pointer {
+                parameters: WDActions::PointerActionParameters {
+                    pointer_type: WDActions::PointerType::Pen,
+                },
+                actions: pa.actions.into_iter().map(|x| x.into_item()).collect(),
+            },
+        })
+    }
+}
+
+/// A sequence containing `Pointer` actions for a touch device.
+#[derive(Debug, Clone)]
+pub struct TouchActions {
+    /// An identifier to distinguish this sequence from others.
+    ///
+    /// Choose a meaningful string as it may be useful for debugging.
+    id: String,
+    /// The list of actions for this sequence.
+    actions: Vec<PointerAction>,
+}
+
+impl TouchActions {
+    /// Create a new `TouchActions` sequence.
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            actions: Vec::new(),
+        }
+    }
+}
+
+impl From<TouchActions> for ActionSequence {
+    fn from(ta: TouchActions) -> Self {
+        ActionSequence(WDActions::ActionSequence {
+            id: ta.id,
+            actions: WDActions::ActionsType::Pointer {
+                parameters: WDActions::PointerActionParameters {
+                    pointer_type: WDActions::PointerType::Touch,
+                },
+                actions: ta.actions.into_iter().map(|x| x.into_item()).collect(),
+            },
+        })
+    }
+}
+
+/// A sequence of actions to be performed.
+///
+/// See the documentation for [`Actions`] for more details.
+#[derive(Debug)]
+pub struct ActionSequence(pub(crate) WDActions::ActionSequence);
+
+/// Each sequence type implements `InputSource` which provides a `pause()` and a `then()`
+/// method. Each call to `pause()` or `then()` represents one tick for this sequence.
+pub trait InputSource: Into<ActionSequence> {
+    /// The action type associated with this `InputSource`.
+    type Action;
+
+    /// Add a pause action to the sequence for this input source.
+    fn pause(self, duration: Duration) -> Self;
+
+    /// Add the specified action to the sequence for this input source.
+    fn then(self, action: Self::Action) -> Self;
+}
+
+impl InputSource for NullActions {
+    type Action = NullAction;
+
+    fn pause(self, duration: Duration) -> Self {
+        self.then(NullAction::Pause { duration })
     }
 
-    /// Add the specified action to this channel.
-    pub fn then(&mut self, action: PointerAction) -> &mut Self {
+    fn then(mut self, action: Self::Action) -> Self {
         self.actions.push(action);
         self
     }
 }
 
-/// An ActionChannel is a sequence of actions of a specific type.
+impl InputSource for KeyActions {
+    type Action = KeyAction;
+
+    fn pause(self, duration: Duration) -> Self {
+        self.then(KeyAction::Pause { duration })
+    }
+
+    fn then(mut self, action: Self::Action) -> Self {
+        self.actions.push(action);
+        self
+    }
+}
+
+impl InputSource for MouseActions {
+    type Action = PointerAction;
+
+    fn pause(self, duration: Duration) -> Self {
+        self.then(PointerAction::Pause { duration })
+    }
+
+    fn then(mut self, action: Self::Action) -> Self {
+        self.actions.push(action);
+        self
+    }
+}
+
+impl InputSource for PenActions {
+    type Action = PointerAction;
+
+    fn pause(self, duration: Duration) -> Self {
+        self.then(PointerAction::Pause { duration })
+    }
+
+    fn then(mut self, action: Self::Action) -> Self {
+        self.actions.push(action);
+        self
+    }
+}
+
+impl InputSource for TouchActions {
+    type Action = PointerAction;
+
+    fn pause(self, duration: Duration) -> Self {
+        self.then(PointerAction::Pause { duration })
+    }
+
+    fn then(mut self, action: Self::Action) -> Self {
+        self.actions.push(action);
+        self
+    }
+}
+
+/// A list of action sequences to be performed via `Client::perform_actions()`
 ///
-/// When combined with other channels, you can think of them like a table, where each
-/// row contains a channel and each column is 1 "tick" of time. The duration of any given
-/// tick will be equal to the longest duration of any individual action in that column.
+/// An [`ActionSequence`] is a sequence of actions of a specific type.
+///
+/// Multiple sequences can be represented as a table, where each row contains a
+/// sequence and each column is 1 "tick" of time. The duration of any given tick
+/// will be equal to the longest duration of any individual action in that column.
 ///
 /// See the following example diagram:
 ///
 /// ```ignore
-///   Tick ->                 1          2                     3
+///   Tick ->              1         2                     3
 /// |===================================================================
-/// | KeyActionChannel      |  Down   |  Up                 |  Pause  |
+/// | KeyActions        |  Down   |  Up                 |  Pause  |
 /// |-------------------------------------------------------------------
-/// | PointerActionChannel  |  Down   |  Pause (2 seconds)  |  Up     |
+/// | PointerActions    |  Down   |  Pause (2 seconds)  |  Up     |
 /// |-------------------------------------------------------------------
-/// | (other channel type)  |  Pause  |  Pause              |  Pause  |
+/// | (other sequence)  |  Pause  |  Pause              |  Pause  |
 /// |===================================================================
 /// ```
 ///
 /// At tick 1, both a `KeyAction::Down` and a `PointerAction::Down` are triggered
 /// simultaneously.
 ///
-/// At tick 2, only a `KeyAction::Up` is triggered. Meanwhile the pointer channel
+/// At tick 2, only a `KeyAction::Up` is triggered. Meanwhile the pointer sequence
 /// has a `PointerAction::Pause` for 2 seconds. Note that tick 3 does not start
 /// until all of the actions from tick 2 have completed, including any pauses.
 ///
 /// At tick 3, only a `PointerAction::Up` is triggered.
 ///
-/// The bottom channel is just to show that other channels can be added. This could
-/// be any channel type, including an additional `Key` or `Pointer` channel. There
-/// is no theoretical limit to the number of channels that can be specified.
-///
-#[derive(Debug, Clone)]
-pub enum ActionChannel {
-    /// A channel containing null actions.
-    Null(NullActionChannel),
-    /// A channel containing key actions.
-    Key(KeyActionChannel),
-    /// A channel containing pointer actions. All actions in the channel are for a single
-    /// pointer type.
-    Pointer(PointerActionChannel),
-}
-
-impl ActionChannel {
-    /// Add a pause action for this channel.
-    pub fn pause(&mut self, duration: Duration) -> &mut Self {
-        match self {
-            ActionChannel::Null(channel) => {
-                channel.pause(duration);
-            }
-            ActionChannel::Key(channel) => {
-                channel.pause(duration);
-            }
-            ActionChannel::Pointer(channel) => {
-                channel.pause(duration);
-            }
-        }
-        self
-    }
-
-    fn into_sequence(self) -> WDActions::ActionSequence {
-        match self {
-            ActionChannel::Null(channel) => WDActions::ActionSequence {
-                id: channel.id,
-                actions: WDActions::ActionsType::Null {
-                    actions: channel.actions.into_iter().map(|x| x.into_item()).collect(),
-                },
-            },
-            ActionChannel::Key(channel) => WDActions::ActionSequence {
-                id: channel.id,
-                actions: WDActions::ActionsType::Key {
-                    actions: channel.actions.into_iter().map(|x| x.into_item()).collect(),
-                },
-            },
-            ActionChannel::Pointer(channel) => WDActions::ActionSequence {
-                id: channel.id,
-                actions: WDActions::ActionsType::Pointer {
-                    parameters: WDActions::PointerActionParameters {
-                        pointer_type: channel.pointer_type.into_wd_pointertype(),
-                    },
-                    actions: channel.actions.into_iter().map(|x| x.into_item()).collect(),
-                },
-            },
-        }
-    }
-}
-
-/// An Action Chain is simply a list of channels. See the documentation for `ActionChannel`
-/// for more details.
-///
-/// Also see `ActionChainBuilder` for a convenient, high-level way to create an `ActionChain`.
-#[derive(Debug, Clone, Default)]
-pub struct ActionChain {
-    channels: Vec<ActionChannel>,
-}
-
-impl ActionChain {
-    /// Create a new ActionChain.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Create an ActionChainBuilder.
-    pub fn builder() -> ActionChainBuilder {
-        ActionChainBuilder::default()
-    }
-
-    /// Add a complete channel to this ActionChain. This allows more flexibility if you want
-    /// to create your own channels and then add them here.
-    pub fn add_channel(&mut self, channel: ActionChannel) {
-        self.channels.push(channel);
-    }
-}
-
-impl ActionChain {
-    pub(crate) fn into_params(self) -> webdriver::command::ActionsParameters {
-        webdriver::command::ActionsParameters {
-            actions: self
-                .channels
-                .into_iter()
-                .map(|x| x.into_sequence())
-                .collect(),
-        }
-    }
-}
-
-/// Builder for an ActionChain. Use `ActionChain::builder()` to create one.
+/// The bottom sequence is just to show that other sequences can be added. This could
+/// be any of `NullActions`, `KeyActions` or `PointerActions`. There is no theoretical
+/// limit to the number of sequences that can be specified.
 #[derive(Debug)]
-pub struct ActionChainBuilder {
-    default_duration: Duration,
-    key_channel: KeyActionChannel,
-    mouse_channel: PointerActionChannel,
+pub struct Actions {
+    pub(crate) client: Client,
+    pub(crate) sequences: Vec<ActionSequence>,
 }
 
-impl Default for ActionChainBuilder {
-    fn default() -> Self {
-        Self {
-            default_duration: Duration::default(),
-            key_channel: KeyActionChannel::new("key"),
-            mouse_channel: PointerActionChannel::new("pointer", PointerActionType::Mouse),
-        }
-    }
-}
-
-impl ActionChainBuilder {
-    /// Update the default pause interval. This will only affect actions added after this point.
-    pub fn change_tick_interval(mut self, duration: Duration) -> Self {
-        self.default_duration = duration;
+impl Actions {
+    /// Append the specified sequence to the list of sequences.
+    pub fn and(mut self, sequence: impl Into<ActionSequence>) -> Self {
+        self.sequences.push(sequence.into());
         self
-    }
-
-    /// Construct an ActionChain from this ActionChainBuilder.
-    pub fn build(self) -> ActionChain {
-        let mut chain = ActionChain::new();
-        if !self.key_channel.actions.is_empty() {
-            chain.add_channel(ActionChannel::Key(self.key_channel));
-        }
-
-        if !self.mouse_channel.actions.is_empty() {
-            chain.add_channel(ActionChannel::Pointer(self.mouse_channel));
-        }
-
-        chain
-    }
-
-    fn add_key_pause(&mut self) {
-        self.key_channel.pause(self.default_duration);
-    }
-
-    fn add_mouse_pause(&mut self) {
-        self.mouse_channel.pause(self.default_duration);
-    }
-
-    /// Add a pause for the specified duration.
-    pub fn pause(mut self, duration: Duration) -> Self {
-        self.key_channel.pause(duration);
-        self.mouse_channel.pause(duration);
-        self
-    }
-
-    /// Add a mouse button down action. Button values are as follows:
-    /// - Left = 0
-    /// - Middle = 1
-    /// - Right = 2
-    pub fn button_down(mut self, button: u64) -> Self {
-        self.mouse_channel.then(PointerAction::Down { button });
-        self.add_key_pause();
-        self
-    }
-
-    /// Add a mouse button up action.
-    ///
-    /// Button values are as follows:
-    /// - Left = 0
-    /// - Middle = 1
-    /// - Right = 2
-    pub fn button_up(mut self, button: u64) -> Self {
-        self.mouse_channel.then(PointerAction::Up { button });
-        self.add_key_pause();
-        self
-    }
-
-    /// Add a mouse move action.
-    ///
-    /// The `x_offset` and `y_offset` values are relative to the current mouse position.
-    pub fn move_by(mut self, x_offset: i64, y_offset: i64) -> Self {
-        self.mouse_channel.then(PointerAction::Move {
-            duration: self.default_duration.as_millis() as u64,
-            origin: PointerOrigin::Pointer,
-            x: x_offset,
-            y: y_offset,
-        });
-        self.add_key_pause();
-        self
-    }
-
-    /// Add a mouse move action.
-    ///
-    /// The `x` and `y` values are relative to the top left corner of the browser window.
-    pub fn move_to(mut self, x: i64, y: i64) -> Self {
-        self.mouse_channel.then(PointerAction::Move {
-            duration: self.default_duration.as_millis() as u64,
-            origin: PointerOrigin::Viewport,
-            x,
-            y,
-        });
-        self.add_key_pause();
-        self
-    }
-
-    /// Add an action to move the mouse to the specified element.
-    ///
-    /// The `x` and `y` values are relative to the element's center position.
-    pub fn move_to_element_with_offset(mut self, element: Element, x: i64, y: i64) -> Self {
-        self.mouse_channel.then(PointerAction::Move {
-            duration: self.default_duration.as_millis() as u64,
-            origin: PointerOrigin::WebElement(element),
-            x,
-            y,
-        });
-        self.add_key_pause();
-        self
-    }
-
-    /// Add an action to move the mouse cursor to the center of the specified element.
-    pub fn move_to_element(self, element: Element) -> Self {
-        self.move_to_element_with_offset(element, 0, 0)
-    }
-
-    /// Add an action to click the specified mouse button.
-    ///
-    /// Button values are as follows:
-    /// - Left = 0
-    /// - Middle = 1
-    /// - Right = 2
-    pub fn click_button(self, button: u64) -> Self {
-        self.button_down(button).button_up(button)
-    }
-
-    /// Add an action to double-click the specified mouse button.
-    ///
-    /// Button values are as follows:
-    /// - Left = 0
-    /// - Middle = 1
-    /// - Right = 2
-    pub fn double_click_button(self, button: u64) -> Self {
-        self.click_button(button).click_button(button)
-    }
-
-    /// Add an action to click the left mouse button.
-    pub fn click(self) -> Self {
-        self.click_button(0)
-    }
-
-    /// Add an action to double-click the left mouse button.
-    pub fn double_click(self) -> Self {
-        self.double_click_button(0)
-    }
-
-    /// Add an action to click the left mouse button on the center point of the
-    /// specified element.
-    pub fn click_element(self, element: Element) -> Self {
-        self.move_to_element(element).click()
-    }
-
-    /// Add an action to click the specified mouse button on the center point of the
-    /// specified element.
-    pub fn click_element_with_button(self, element: Element, button: u64) -> Self {
-        self.move_to_element(element).click_button(button)
-    }
-
-    /// Add an action to double-click the left mouse button on the center point of the
-    /// specified element.
-    pub fn double_click_element(self, element: Element) -> Self {
-        self.move_to_element(element).double_click()
-    }
-
-    /// Add an action to double-click the specified mouse button on the center point of the
-    /// specified element.
-    pub fn double_click_element_with_button(self, element: Element, button: u64) -> Self {
-        self.move_to_element(element).double_click_button(button)
-    }
-
-    /// Add an action to click the specified mouse button on the center point of the
-    /// source element, then drag to the center point of the target element, and then
-    /// release the same mouse button.
-    ///
-    /// Button values are as follows:
-    /// - Left = 0
-    /// - Middle = 1
-    /// - Right = 2
-    pub fn drag_and_drop_element_with_button(
-        self,
-        source: Element,
-        target: Element,
-        button: u64,
-    ) -> Self {
-        self.move_to_element(source)
-            .button_down(button)
-            .move_to_element(target)
-            .button_up(button)
-    }
-
-    /// Add an action to click the left mouse button on the center point of the source
-    /// element, then drag to the center point of the target element, and then release
-    /// the left mouse button.
-    pub fn drag_and_drop_element(self, source: Element, target: Element) -> Self {
-        self.drag_and_drop_element_with_button(source, target, 0)
-    }
-
-    /// Add a key down action for the specified character.
-    ///
-    /// See [`Key`] for the codes for special keyboard buttons.
-    pub fn key_down(mut self, value: char) -> Self {
-        self.key_channel.then(KeyAction::Down { value });
-        self.add_mouse_pause();
-        self
-    }
-
-    /// Add a key up action for the specified character.
-    ///
-    /// See [`Key`] for the codes for special keyboard buttons.
-    pub fn key_up(mut self, value: char) -> Self {
-        self.key_channel.then(KeyAction::Up { value });
-        self.add_mouse_pause();
-        self
-    }
-
-    /// Add a key down + key up action for each character in the specified string.
-    ///
-    /// See [`Key`] for the codes for special keyboard buttons.
-    pub fn send_keys(mut self, text: &str) -> Self {
-        for c in text.chars() {
-            self = self.key_down(c).key_up(c)
-        }
-        self
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::elements::ElementId;
-    use crate::Client;
-    use serde_json::json;
-    use tokio::sync::mpsc::unbounded_channel;
-
-    use super::*;
-
-    fn compare_null_action(action: NullAction, value: serde_json::Value) {
-        let channel = ActionChannel::Null(NullActionChannel {
-            id: "null".to_string(),
-            actions: vec![action],
-        });
-
-        let value_got = serde_json::to_value(channel.into_sequence());
-        assert!(value_got.is_ok());
-        assert_eq!(
-            value_got.unwrap(),
-            json!({
-                "id": "null",
-                "type": "none",
-                "actions": [ value ]
-            })
-        );
-    }
-
-    #[test]
-    fn test_null_action() {
-        compare_null_action(
-            NullAction::Pause {
-                duration: Duration::from_millis(0),
-            },
-            json!({"type": "pause", "duration": 0}),
-        );
-
-        compare_null_action(
-            NullAction::Pause {
-                duration: Duration::from_millis(4),
-            },
-            json!({"type": "pause", "duration": 4}),
-        );
-    }
-
-    fn compare_key_action(action: KeyAction, value: serde_json::Value) {
-        let channel = ActionChannel::Key(KeyActionChannel {
-            id: "key".to_string(),
-            actions: vec![action],
-        });
-
-        let value_got = serde_json::to_value(channel.into_sequence());
-        assert!(value_got.is_ok());
-        assert_eq!(
-            value_got.unwrap(),
-            json!({
-                "id": "key",
-                "type": "key",
-                "actions": [ value ]
-            })
-        );
-    }
-
-    #[test]
-    fn test_key_action_pause() {
-        compare_key_action(
-            KeyAction::Pause {
-                duration: Duration::from_millis(0),
-            },
-            json!({"type": "pause", "duration": 0}),
-        );
-
-        compare_key_action(
-            KeyAction::Pause {
-                duration: Duration::from_millis(3),
-            },
-            json!({"type": "pause", "duration": 3}),
-        );
-    }
-
-    #[test]
-    fn test_key_action_updown() {
-        compare_key_action(
-            KeyAction::Down { value: 'a' },
-            json!({"type": "keyDown", "value": 'a'}),
-        );
-
-        compare_key_action(
-            KeyAction::Down { value: '\u{e004}' },
-            json!({
-            "type": "keyDown", "value": '\u{e004}'
-            }),
-        );
-
-        compare_key_action(
-            KeyAction::Up { value: 'a' },
-            json!({"type": "keyUp", "value": 'a'}),
-        );
-
-        compare_key_action(
-            KeyAction::Up { value: '\u{e004}' },
-            json!({
-            "type": "keyUp", "value": '\u{e004}'
-            }),
-        );
-    }
-
-    fn compare_pointer_action(action: PointerAction, value: serde_json::Value) {
-        let channel = ActionChannel::Pointer(PointerActionChannel {
-            id: "mouse".to_string(),
-            pointer_type: PointerActionType::Mouse,
-            actions: vec![action],
-        });
-
-        let value_got = serde_json::to_value(channel.into_sequence());
-        assert!(value_got.is_ok());
-        assert_eq!(
-            value_got.unwrap(),
-            json!({
-                "id": "mouse",
-                "type": "pointer",
-                "parameters": {
-                    "pointerType": "mouse"
-                },
-                "actions": [ value ]
-            })
-        );
-    }
-
-    #[test]
-    fn test_pointer_action_pause() {
-        compare_pointer_action(
-            PointerAction::Pause {
-                duration: Duration::from_millis(0),
-            },
-            json!({"type": "pause", "duration": 0}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Pause {
-                duration: Duration::from_millis(2),
-            },
-            json!({"type": "pause", "duration": 2}),
-        );
-    }
-
-    #[test]
-    fn test_pointer_action_button() {
-        compare_pointer_action(
-            PointerAction::Down { button: 0 },
-            json!({"type": "pointerDown", "button": 0}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Down { button: 1 },
-            json!({"type": "pointerDown", "button": 1}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Down { button: 2 },
-            json!({"type": "pointerDown", "button": 2}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Up { button: 0 },
-            json!({"type": "pointerUp", "button": 0}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Up { button: 1 },
-            json!({"type": "pointerUp", "button": 1}),
-        );
-
-        compare_pointer_action(
-            PointerAction::Up { button: 2 },
-            json!({"type": "pointerUp", "button": 2}),
-        );
-    }
-
-    #[test]
-    fn test_pointer_action_pointermove() {
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 0,
-                x: 0,
-                y: 0,
-                origin: PointerOrigin::Viewport,
-            },
-            json!({
-            "type": "pointerMove", "origin": "viewport", "x": 0, "y": 0, "duration": 0
-            }),
-        );
-
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 0,
-                x: 0,
-                y: 0,
-                origin: PointerOrigin::Pointer,
-            },
-            json!({
-            "type": "pointerMove", "origin": "pointer", "x": 0, "y": 0, "duration": 0
-            }),
-        );
-
-        let (tx, _) = unbounded_channel();
-        let fake_client = Client {
-            tx,
-            is_legacy: false,
-        };
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 0,
-                x: 0,
-                y: 0,
-                origin: PointerOrigin::WebElement(Element::from_element_id(
-                    fake_client.clone(),
-                    ElementId("id1234".to_string()),
-                )),
-            },
-            json!({
-            "type": "pointerMove", "origin": {"element-6066-11e4-a52e-4f735466cecf": "id1234"}, "x": 0, "y": 0, "duration": 0
-            }),
-        );
-
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 1,
-                x: 100,
-                y: 200,
-                origin: PointerOrigin::Viewport,
-            },
-            json!({
-                "type": "pointerMove",
-                "x": 100,
-                "y": 200,
-                "duration": 1,
-                "origin": "viewport"
-            }),
-        );
-
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 1,
-                x: 100,
-                y: 200,
-                origin: PointerOrigin::Pointer,
-            },
-            json!({
-                "type": "pointerMove",
-                "x": 100,
-                "y": 200,
-                "duration": 1,
-                "origin": "pointer"
-            }),
-        );
-
-        compare_pointer_action(
-            PointerAction::Move {
-                duration: 1,
-                x: 100,
-                y: 200,
-                origin: PointerOrigin::WebElement(Element::from_element_id(
-                    fake_client,
-                    ElementId("someid".to_string()),
-                )),
-            },
-            json!({
-                "type": "pointerMove",
-                "x": 100,
-                "y": 200,
-                "duration": 1,
-                "origin": {"element-6066-11e4-a52e-4f735466cecf": "someid"}
-            }),
-        );
-    }
-
-    #[test]
-    fn test_pointer_action_cancel() {
-        compare_pointer_action(PointerAction::Cancel, json!({"type": "pointerCancel"}));
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,874 @@
+//! Actions functionality for WebDriver.
+use crate::elements::Element;
+use std::fmt::Debug;
+use std::time::Duration;
+use webdriver::actions as WDActions;
+
+/// An action not associated with an input device (i.e. pause).
+#[derive(Debug, Clone)]
+pub enum NullAction {
+    /// Pause for the specified duration.
+    Pause {
+        /// The pause duration, given in milliseconds.
+        duration: u64,
+    },
+}
+
+impl From<NullAction> for WDActions::NullActionItem {
+    fn from(na: NullAction) -> Self {
+        match na {
+            NullAction::Pause { duration } => WDActions::NullActionItem::General(
+                WDActions::GeneralAction::Pause(WDActions::PauseAction {
+                    duration: Some(duration),
+                }),
+            ),
+        }
+    }
+}
+
+/// An action performed with a keyboard.
+#[derive(Debug, Clone)]
+pub enum KeyAction {
+    /// Pause action.
+    /// Useful for adding pauses between other key actions.
+    Pause {
+        /// The pause duration, given in milliseconds.
+        duration: u64,
+    },
+    /// Key up action.
+    Up {
+        /// The key code, e.g. `'a'`. See the [`Keys`] module for special key codes.
+        ///
+        /// [`Keys`]: crate::Keys
+        value: char,
+    },
+    /// Key down action.
+    Down {
+        /// The key code, e.g. `'a'`. See the [`Keys`] module for special key codes.
+        ///
+        /// [`Keys`]: crate::Keys
+        value: char,
+    },
+}
+
+impl From<KeyAction> for WDActions::KeyActionItem {
+    fn from(ka: KeyAction) -> Self {
+        use webdriver::actions::{KeyAction as WDKeyAction, KeyDownAction, KeyUpAction};
+        match ka {
+            KeyAction::Pause { duration } => WDActions::KeyActionItem::General(
+                WDActions::GeneralAction::Pause(WDActions::PauseAction {
+                    duration: Some(duration),
+                }),
+            ),
+            KeyAction::Up { value } => {
+                WDActions::KeyActionItem::Key(WDKeyAction::Up(KeyUpAction {
+                    value: value.to_string(),
+                }))
+            }
+            KeyAction::Down { value } => {
+                WDActions::KeyActionItem::Key(WDKeyAction::Down(KeyDownAction {
+                    value: value.to_string(),
+                }))
+            }
+        }
+    }
+}
+
+/// An action performed with a pointer device. See `PointerActionType` for
+/// the availabledevice types.
+#[derive(Debug, Clone)]
+pub enum PointerAction {
+    /// Pause action.
+    /// Useful for adding pauses between other key actions.
+    Pause {
+        /// The pause duration, given in milliseconds.
+        duration: u64,
+    },
+    /// Pointer button down.
+    Down {
+        /// The mouse button index. Button values are as follows:
+        /// - Left = 0
+        /// - Middle = 1
+        /// - Right = 2
+        button: u64,
+    },
+    /// Pointer button up.
+    Up {
+        /// The mouse button index. Button values are as follows:
+        /// - Left = 0
+        /// - Middle = 1
+        /// - Right = 2
+        button: u64,
+    },
+    /// Pointer move action. Duration is specified in milliseconds (can be 0).
+    /// The x and y offsets are relative to the origin.
+    Move {
+        /// The move duration, given in milliseconds.
+        duration: u64,
+        /// The origin that the `x` and `y` coordinates are relative to.
+        origin: PointerOrigin,
+        /// `x` offset, in pixels.
+        x: i64,
+        /// `y` offset, in pixels.
+        y: i64,
+    },
+    /// Pointer cancel action. Used to cancel the current pointer action.
+    Cancel,
+}
+
+/// The pointer origin to use for the relative x,y offset.
+#[derive(Debug, Clone)]
+pub enum PointerOrigin {
+    /// Coordinates are relative to the top-left corner of the browser window.
+    Viewport,
+    /// Coordinates are relative to the pointer's current position.
+    Pointer,
+    /// Coordinates are relative to the specified element's center position.
+    WebElement(Element),
+}
+
+impl From<PointerOrigin> for WDActions::PointerOrigin {
+    fn from(po: PointerOrigin) -> Self {
+        match po {
+            PointerOrigin::Viewport => WDActions::PointerOrigin::Viewport,
+            PointerOrigin::Pointer => WDActions::PointerOrigin::Pointer,
+            PointerOrigin::WebElement(e) => WDActions::PointerOrigin::Element(
+                webdriver::common::WebElement(e.element_id().to_string()),
+            ),
+        }
+    }
+}
+
+/// The type of pointer.
+#[derive(Debug, Clone)]
+pub enum PointerActionType {
+    /// A mouse pointer device.
+    Mouse,
+    /// A pen device.
+    Pen,
+    /// A touch device.
+    Touch,
+}
+
+impl From<PointerActionType> for WDActions::PointerType {
+    fn from(pat: PointerActionType) -> Self {
+        match pat {
+            PointerActionType::Mouse => WDActions::PointerType::Mouse,
+            PointerActionType::Pen => WDActions::PointerType::Pen,
+            PointerActionType::Touch => WDActions::PointerType::Touch,
+        }
+    }
+}
+
+impl From<PointerAction> for WDActions::PointerActionItem {
+    fn from(pa: PointerAction) -> Self {
+        match pa {
+            PointerAction::Pause { duration } => WDActions::PointerActionItem::General(
+                WDActions::GeneralAction::Pause(WDActions::PauseAction {
+                    duration: Some(duration),
+                }),
+            ),
+            PointerAction::Down { button } => WDActions::PointerActionItem::Pointer(
+                WDActions::PointerAction::Down(WDActions::PointerDownAction { button }),
+            ),
+            PointerAction::Up { button } => WDActions::PointerActionItem::Pointer(
+                WDActions::PointerAction::Up(WDActions::PointerUpAction { button }),
+            ),
+            PointerAction::Move {
+                duration,
+                origin,
+                x,
+                y,
+            } => WDActions::PointerActionItem::Pointer(WDActions::PointerAction::Move(
+                WDActions::PointerMoveAction {
+                    duration: Some(duration),
+                    origin: origin.into(),
+                    x: Some(x),
+                    y: Some(y),
+                },
+            )),
+            PointerAction::Cancel => {
+                WDActions::PointerActionItem::Pointer(WDActions::PointerAction::Cancel)
+            }
+        }
+    }
+}
+
+/// A channel containing `Null` actions.
+#[derive(Debug, Clone)]
+pub struct NullActionChannel {
+    /// An identifier to distinguish this channel from others. Choose a meaningful string.
+    /// May be useful for debugging.
+    id: String,
+    /// The list of actions for this channel.
+    actions: Vec<NullAction>,
+}
+
+impl NullActionChannel {
+    /// Create a new NullActionChannel.
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            actions: Vec::new(),
+        }
+    }
+
+    /// Add a pause action to this channel.
+    pub fn add_pause(&mut self, duration: Duration) {
+        self.add_action(NullAction::Pause {
+            duration: duration.as_millis() as u64,
+        });
+    }
+
+    /// Add the specified action to this channel.
+    pub fn add_action(&mut self, action: NullAction) {
+        self.actions.push(action);
+    }
+}
+
+/// A channel containing `Key` actions.
+#[derive(Debug, Clone)]
+pub struct KeyActionChannel {
+    /// An identifier to distinguish this channel from others. Choose a meaningful string.
+    /// May be useful for debugging.
+    id: String,
+    /// The list of actions for this channel.
+    actions: Vec<KeyAction>,
+}
+
+impl KeyActionChannel {
+    /// Create a new Key channel.
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            actions: Vec::new(),
+        }
+    }
+
+    /// Add a pause action to this channel.
+    pub fn add_pause(&mut self, duration: Duration) {
+        self.add_action(KeyAction::Pause {
+            duration: duration.as_millis() as u64,
+        });
+    }
+
+    /// Add the specified action to this channel.
+    pub fn add_action(&mut self, action: KeyAction) {
+        self.actions.push(action);
+    }
+}
+
+/// A channel containing `Key` actions.
+#[derive(Debug, Clone)]
+pub struct PointerActionChannel {
+    /// An identifier to distinguish this channel from others. Choose a meaningful string.
+    /// May be useful for debugging.
+    id: String,
+    /// The pointer type. Can be `Mouse`, `Pen` or `Touch`.
+    pointer_type: PointerActionType,
+    /// The list of actions for this channel.
+    actions: Vec<PointerAction>,
+}
+
+impl PointerActionChannel {
+    /// Create a new Pointer channel.
+    pub fn new(id: &str, pointer_type: PointerActionType) -> Self {
+        Self {
+            id: id.to_string(),
+            pointer_type,
+            actions: Vec::new(),
+        }
+    }
+
+    /// Add a pause action to this channel.
+    pub fn add_pause(&mut self, duration: Duration) {
+        self.add_action(PointerAction::Pause {
+            duration: duration.as_millis() as u64,
+        });
+    }
+
+    /// Add the specified action to this channel.
+    pub fn add_action(&mut self, action: PointerAction) {
+        self.actions.push(action);
+    }
+}
+
+/// An ActionChannel is a sequence of actions of a specific type.
+/// When combined with other channels, you can think of them like a grid, with actions on the
+/// horizontal axis and channels on the vertical axis. All of the actions in the first column
+/// will be executed simultaneously, then all of the second actions, and so on.
+/// The second column will not be executed until all actions in the first column have been
+/// completed, including any pauses.
+///
+/// Thus, the duration of each column will be equal to the longest duration of any individual
+/// action in that column.
+#[derive(Debug, Clone)]
+pub enum ActionChannel {
+    /// A channel containing null actions.
+    Null(NullActionChannel),
+    /// A channel containing key actions.
+    Key(KeyActionChannel),
+    /// A channel containing pointer actions. All actions in the channel are for a single
+    /// pointer type.
+    Pointer(PointerActionChannel),
+}
+
+impl ActionChannel {
+    /// Add a pause action for this channel.
+    pub fn add_pause(&mut self, duration: Duration) {
+        match self {
+            ActionChannel::Null(channel) => channel.add_pause(duration),
+            ActionChannel::Key(channel) => channel.add_pause(duration),
+            ActionChannel::Pointer(channel) => channel.add_pause(duration),
+        }
+    }
+
+    fn into_sequence(self) -> WDActions::ActionSequence {
+        match self {
+            ActionChannel::Null(channel) => WDActions::ActionSequence {
+                id: channel.id,
+                actions: WDActions::ActionsType::Null {
+                    actions: channel.actions.into_iter().map(|x| x.into()).collect(),
+                },
+            },
+            ActionChannel::Key(channel) => WDActions::ActionSequence {
+                id: channel.id,
+                actions: WDActions::ActionsType::Key {
+                    actions: channel.actions.into_iter().map(|x| x.into()).collect(),
+                },
+            },
+            ActionChannel::Pointer(channel) => WDActions::ActionSequence {
+                id: channel.id,
+                actions: WDActions::ActionsType::Pointer {
+                    parameters: WDActions::PointerActionParameters {
+                        pointer_type: channel.pointer_type.into(),
+                    },
+                    actions: channel.actions.into_iter().map(|x| x.into()).collect(),
+                },
+            },
+        }
+    }
+}
+
+/// An Action Chain is simply a list of channels. See the documentation for `ActionChannel`
+/// for more details.
+///
+/// Also see `ActionChainBuilder` for a convenient, high-level way to create an `ActionChain`.
+#[derive(Debug, Clone, Default)]
+pub struct ActionChain {
+    channels: Vec<ActionChannel>,
+}
+
+impl ActionChain {
+    /// Create a new ActionChain.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an ActionChainBuilder.
+    pub fn builder() -> ActionChainBuilder {
+        ActionChainBuilder::default()
+    }
+
+    /// Add a complete channel to this ActionChain. This allows more flexibility if you want
+    /// to create your own channels and then add them here.
+    pub fn add_channel(&mut self, channel: ActionChannel) {
+        self.channels.push(channel);
+    }
+}
+
+impl From<ActionChain> for webdriver::command::ActionsParameters {
+    fn from(ac: ActionChain) -> Self {
+        let mut sequences = Vec::new();
+
+        for channel in ac.channels {
+            sequences.push(channel.into_sequence());
+        }
+
+        webdriver::command::ActionsParameters { actions: sequences }
+    }
+}
+
+/// Builder for an ActionChain. Use `ActionChain::builder()` to create one.
+#[derive(Debug)]
+pub struct ActionChainBuilder {
+    default_duration: Duration,
+    key_channel: KeyActionChannel,
+    mouse_channel: PointerActionChannel,
+}
+
+impl Default for ActionChainBuilder {
+    fn default() -> Self {
+        Self {
+            default_duration: Duration::default(),
+            key_channel: KeyActionChannel::new("key"),
+            mouse_channel: PointerActionChannel::new("pointer", PointerActionType::Mouse),
+        }
+    }
+}
+
+impl ActionChainBuilder {
+    /// Update the default pause interval. This will only affect actions added after this point.
+    pub fn change_tick_interval(mut self, duration: Duration) -> Self {
+        self.default_duration = duration;
+        self
+    }
+
+    /// Construct an ActionChain from this ActionChainBuilder.
+    pub fn build(self) -> ActionChain {
+        let mut chain = ActionChain::new();
+        if !self.key_channel.actions.is_empty() {
+            chain.add_channel(ActionChannel::Key(self.key_channel));
+        }
+
+        if !self.mouse_channel.actions.is_empty() {
+            chain.add_channel(ActionChannel::Pointer(self.mouse_channel));
+        }
+
+        chain
+    }
+
+    fn add_key_pause(&mut self) {
+        self.key_channel.add_pause(self.default_duration);
+    }
+
+    fn add_mouse_pause(&mut self) {
+        self.mouse_channel.add_pause(self.default_duration);
+    }
+
+    /// Add a pause for the specified duration.
+    pub fn pause(mut self, duration: Duration) -> Self {
+        self.key_channel.add_pause(duration);
+        self.mouse_channel.add_pause(duration);
+        self
+    }
+
+    /// Add a mouse button down action. Button values are as follows:
+    /// - Left = 0
+    /// - Middle = 1
+    /// - Right = 2
+    pub fn button_down(mut self, button: u64) -> Self {
+        self.mouse_channel
+            .add_action(PointerAction::Down { button });
+        self.add_key_pause();
+        self
+    }
+
+    /// Add a mouse button up action. Button values are as follows:
+    /// - Left = 0
+    /// - Middle = 1
+    /// - Right = 2
+    pub fn button_up(mut self, button: u64) -> Self {
+        self.mouse_channel.add_action(PointerAction::Up { button });
+        self.add_key_pause();
+        self
+    }
+
+    /// Add a mouse move action. The `x_offset` and `y_offset` values are relative
+    /// to the current mouse position.
+    pub fn move_by(mut self, x_offset: i64, y_offset: i64) -> Self {
+        self.mouse_channel.add_action(PointerAction::Move {
+            duration: self.default_duration.as_millis() as u64,
+            origin: PointerOrigin::Pointer,
+            x: x_offset,
+            y: y_offset,
+        });
+        self.add_key_pause();
+        self
+    }
+
+    /// Add a mouse move action. The `x` and `y` values are relative to the
+    /// top left corner of the browser window.
+    pub fn move_to(mut self, x: i64, y: i64) -> Self {
+        self.mouse_channel.add_action(PointerAction::Move {
+            duration: self.default_duration.as_millis() as u64,
+            origin: PointerOrigin::Viewport,
+            x,
+            y,
+        });
+        self.add_key_pause();
+        self
+    }
+
+    /// Add an action to move the mouse to the specified element. The `x` and `y` values are
+    /// relative to the element's center position.
+    pub fn move_to_element_with_offset(mut self, element: Element, x: i64, y: i64) -> Self {
+        self.mouse_channel.add_action(PointerAction::Move {
+            duration: self.default_duration.as_millis() as u64,
+            origin: PointerOrigin::WebElement(element),
+            x,
+            y,
+        });
+        self.add_key_pause();
+        self
+    }
+
+    /// Add an action to move the mouse cursor to the center of the specified element.
+    pub fn move_to_element(self, element: Element) -> Self {
+        self.move_to_element_with_offset(element, 0, 0)
+    }
+
+    /// Add an action to click the specified mouse button. Button values are as follows:
+    /// - Left = 0
+    /// - Middle = 1
+    /// - Right = 2
+    pub fn click_button(self, button: u64) -> Self {
+        self.button_down(button).button_up(button)
+    }
+
+    /// Add an action to double-click the specified mouse button. Button values are as follows:
+    /// - Left = 0
+    /// - Middle = 1
+    /// - Right = 2
+    pub fn double_click_button(self, button: u64) -> Self {
+        self.click_button(button).click_button(button)
+    }
+
+    /// Add an action to click the left mouse button.
+    pub fn click(self) -> Self {
+        self.click_button(0)
+    }
+
+    /// Add an action to double-click the left mouse button.
+    pub fn double_click(self) -> Self {
+        self.double_click_button(0)
+    }
+
+    /// Add an action to click the left mouse button on the center point of the
+    /// specified element.
+    pub fn click_element(self, element: Element) -> Self {
+        self.move_to_element(element).click()
+    }
+
+    /// Add an action to double-click the left mouse button on the center point of the
+    /// specified element.
+    pub fn double_click_element(self, element: Element) -> Self {
+        self.move_to_element(element).double_click()
+    }
+
+    /// Add an action to click the specified mouse button on the center point of the
+    /// source element, then drag to the center point of the target element, and then
+    /// release the same mouse button.
+    /// Button values are as follows:
+    /// - Left = 0
+    /// - Middle = 1
+    /// - Right = 2
+    pub fn drag_and_drop_element_with_button(
+        self,
+        source: Element,
+        target: Element,
+        button: u64,
+    ) -> Self {
+        self.move_to_element(source)
+            .button_down(button)
+            .move_to_element(target)
+            .button_up(button)
+    }
+
+    /// Add an action to click the left mouse button on the center point of the source
+    /// element, then drag to the center point of the target element, and then release
+    /// the left mouse button.
+    pub fn drag_and_drop_element(self, source: Element, target: Element) -> Self {
+        self.drag_and_drop_element_with_button(source, target, 0)
+    }
+
+    /// Add a key down action for the specified character.
+    /// See [`Keys`] for the codes for special keyboard buttons.
+    ///
+    /// [`Keys`]: crate::Keys
+    pub fn key_down(mut self, value: char) -> Self {
+        self.key_channel.add_action(KeyAction::Down { value });
+        self.add_mouse_pause();
+        self
+    }
+
+    /// Add a key up action for the specified character.
+    /// See [`Keys`] for the codes for special keyboard buttons.
+    ///
+    /// [`Keys`]: crate::Keys
+    pub fn key_up(mut self, value: char) -> Self {
+        self.key_channel.add_action(KeyAction::Up { value });
+        self.add_mouse_pause();
+        self
+    }
+
+    /// Add a key down + key up action for each character in the specified string.
+    /// See [`Keys`] for the codes for special keyboard buttons.
+    ///
+    /// [`Keys`]: crate::Keys
+    pub fn send_keys(mut self, text: &str) -> Self {
+        for c in text.chars() {
+            self = self.key_down(c).key_up(c)
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Client;
+    use serde_json::json;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+
+    fn compare_null_action(action: NullAction, value: serde_json::Value) {
+        let channel = ActionChannel::Null(NullActionChannel {
+            id: "null".to_string(),
+            actions: vec![action],
+        });
+
+        let value_got = serde_json::to_value(channel.into_sequence());
+        assert!(value_got.is_ok());
+        assert_eq!(
+            value_got.unwrap(),
+            json!({
+                "id": "null",
+                "type": "none",
+                "actions": [ value ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_null_action() {
+        compare_null_action(
+            NullAction::Pause { duration: 0 },
+            json!({"type": "pause", "duration": 0}),
+        );
+
+        compare_null_action(
+            NullAction::Pause { duration: 4 },
+            json!({"type": "pause", "duration": 4}),
+        );
+    }
+
+    fn compare_key_action(action: KeyAction, value: serde_json::Value) {
+        let channel = ActionChannel::Key(KeyActionChannel {
+            id: "key".to_string(),
+            actions: vec![action],
+        });
+
+        let value_got = serde_json::to_value(channel.into_sequence());
+        assert!(value_got.is_ok());
+        assert_eq!(
+            value_got.unwrap(),
+            json!({
+                "id": "key",
+                "type": "key",
+                "actions": [ value ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_key_action_pause() {
+        compare_key_action(
+            KeyAction::Pause { duration: 0 },
+            json!({"type": "pause", "duration": 0}),
+        );
+
+        compare_key_action(
+            KeyAction::Pause { duration: 3 },
+            json!({"type": "pause", "duration": 3}),
+        );
+    }
+
+    #[test]
+    fn test_key_action_updown() {
+        compare_key_action(
+            KeyAction::Down { value: 'a' },
+            json!({"type": "keyDown", "value": 'a'}),
+        );
+
+        compare_key_action(
+            KeyAction::Down { value: '\u{e004}' },
+            json!({
+            "type": "keyDown", "value": '\u{e004}'
+            }),
+        );
+
+        compare_key_action(
+            KeyAction::Up { value: 'a' },
+            json!({"type": "keyUp", "value": 'a'}),
+        );
+
+        compare_key_action(
+            KeyAction::Up { value: '\u{e004}' },
+            json!({
+            "type": "keyUp", "value": '\u{e004}'
+            }),
+        );
+    }
+
+    fn compare_pointer_action(action: PointerAction, value: serde_json::Value) {
+        let channel = ActionChannel::Pointer(PointerActionChannel {
+            id: "mouse".to_string(),
+            pointer_type: PointerActionType::Mouse,
+            actions: vec![action],
+        });
+
+        let value_got = serde_json::to_value(channel.into_sequence());
+        assert!(value_got.is_ok());
+        assert_eq!(
+            value_got.unwrap(),
+            json!({
+                "id": "mouse",
+                "type": "pointer",
+                "parameters": {
+                    "pointerType": "mouse"
+                },
+                "actions": [ value ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_pointer_action_pause() {
+        compare_pointer_action(
+            PointerAction::Pause { duration: 0 },
+            json!({"type": "pause", "duration": 0}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Pause { duration: 2 },
+            json!({"type": "pause", "duration": 2}),
+        );
+    }
+
+    #[test]
+    fn test_pointer_action_button() {
+        compare_pointer_action(
+            PointerAction::Down { button: 0 },
+            json!({"type": "pointerDown", "button": 0}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Down { button: 1 },
+            json!({"type": "pointerDown", "button": 1}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Down { button: 2 },
+            json!({"type": "pointerDown", "button": 2}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Up { button: 0 },
+            json!({"type": "pointerUp", "button": 0}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Up { button: 1 },
+            json!({"type": "pointerUp", "button": 1}),
+        );
+
+        compare_pointer_action(
+            PointerAction::Up { button: 2 },
+            json!({"type": "pointerUp", "button": 2}),
+        );
+    }
+
+    #[test]
+    fn test_pointer_action_pointermove() {
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 0,
+                x: 0,
+                y: 0,
+                origin: PointerOrigin::Viewport,
+            },
+            json!({
+            "type": "pointerMove", "origin": "viewport", "x": 0, "y": 0, "duration": 0
+            }),
+        );
+
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 0,
+                x: 0,
+                y: 0,
+                origin: PointerOrigin::Pointer,
+            },
+            json!({
+            "type": "pointerMove", "origin": "pointer", "x": 0, "y": 0, "duration": 0
+            }),
+        );
+
+        let (tx, _) = unbounded_channel();
+        let fake_client = Client {
+            tx,
+            is_legacy: false,
+        };
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 0,
+                x: 0,
+                y: 0,
+                origin: PointerOrigin::WebElement(Element::from_element_id(
+                    fake_client.clone(),
+                    "id1234".to_string(),
+                )),
+            },
+            json!({
+            "type": "pointerMove", "origin": {"element-6066-11e4-a52e-4f735466cecf": "id1234"}, "x": 0, "y": 0, "duration": 0
+            }),
+        );
+
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 1,
+                x: 100,
+                y: 200,
+                origin: PointerOrigin::Viewport,
+            },
+            json!({
+                "type": "pointerMove",
+                "x": 100,
+                "y": 200,
+                "duration": 1,
+                "origin": "viewport"
+            }),
+        );
+
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 1,
+                x: 100,
+                y: 200,
+                origin: PointerOrigin::Pointer,
+            },
+            json!({
+                "type": "pointerMove",
+                "x": 100,
+                "y": 200,
+                "duration": 1,
+                "origin": "pointer"
+            }),
+        );
+
+        compare_pointer_action(
+            PointerAction::Move {
+                duration: 1,
+                x: 100,
+                y: 200,
+                origin: PointerOrigin::WebElement(Element::from_element_id(
+                    fake_client,
+                    "someid".to_string(),
+                )),
+            },
+            json!({
+                "type": "pointerMove",
+                "x": 100,
+                "y": 200,
+                "duration": 1,
+                "origin": {"element-6066-11e4-a52e-4f735466cecf": "someid"}
+            }),
+        );
+    }
+
+    #[test]
+    fn test_pointer_action_cancel() {
+        compare_pointer_action(PointerAction::Cancel, json!({"type": "pointerCancel"}));
+    }
+}

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -112,9 +112,9 @@ pub enum PointerAction {
         ///
         /// The following constants are provided, but any mouse index can be used
         /// to represent the corresponding mouse button.
-        /// - [MOUSE_BUTTON_LEFT]
-        /// - [MOUSE_BUTTON_MIDDLE]
-        /// - [MOUSE_BUTTON_RIGHT]
+        /// - [`MOUSE_BUTTON_LEFT`]
+        /// - [`MOUSE_BUTTON_MIDDLE`]
+        /// - [`MOUSE_BUTTON_RIGHT`]
         button: u64,
     },
     /// Pointer button up.
@@ -123,9 +123,9 @@ pub enum PointerAction {
         ///
         /// The following constants are provided, but any mouse index can be used
         /// to represent the corresponding mouse button.
-        /// - [MOUSE_BUTTON_LEFT]
-        /// - [MOUSE_BUTTON_MIDDLE]
-        /// - [MOUSE_BUTTON_RIGHT]
+        /// - [`MOUSE_BUTTON_LEFT`]
+        /// - [`MOUSE_BUTTON_MIDDLE`]
+        /// - [`MOUSE_BUTTON_RIGHT`]
         button: u64,
     },
     /// Move the pointer relative to the current position.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,4 +1,6 @@
 //! Actions functionality for WebDriver.
+#[cfg(doc)]
+use crate::client::Client;
 use crate::elements::Element;
 #[cfg(doc)]
 use crate::keys::Key;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -540,10 +540,22 @@ impl ActionChainBuilder {
         self.move_to_element(element).click()
     }
 
+    /// Add an action to click the specified mouse button on the center point of the
+    /// specified element.
+    pub fn click_element_with_button(self, element: Element, button: u64) -> Self {
+        self.move_to_element(element).click_button(button)
+    }
+
     /// Add an action to double-click the left mouse button on the center point of the
     /// specified element.
     pub fn double_click_element(self, element: Element) -> Self {
         self.move_to_element(element).double_click()
+    }
+
+    /// Add an action to double-click the specified mouse button on the center point of the
+    /// specified element.
+    pub fn double_click_element_with_button(self, element: Element, button: u64) -> Self {
+        self.move_to_element(element).double_click_button(button)
     }
 
     /// Add an action to click the specified mouse button on the center point of the

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -39,14 +39,14 @@ pub enum KeyAction {
     Up {
         /// The key code, e.g. `'a'`. See the [`Keys`] module for special key codes.
         ///
-        /// [`Keys`]: crate::Keys
+        /// [`Keys`]: crate::keys::Keys
         value: char,
     },
     /// Key down action.
     Down {
         /// The key code, e.g. `'a'`. See the [`Keys`] module for special key codes.
         ///
-        /// [`Keys`]: crate::Keys
+        /// [`Keys`]: crate::keys::Keys
         value: char,
     },
 }
@@ -575,7 +575,7 @@ impl ActionChainBuilder {
     /// Add a key down action for the specified character.
     /// See [`Keys`] for the codes for special keyboard buttons.
     ///
-    /// [`Keys`]: crate::Keys
+    /// [`Keys`]: crate::keys::Keys
     pub fn key_down(mut self, value: char) -> Self {
         self.key_channel.add_action(KeyAction::Down { value });
         self.add_mouse_pause();
@@ -585,7 +585,7 @@ impl ActionChainBuilder {
     /// Add a key up action for the specified character.
     /// See [`Keys`] for the codes for special keyboard buttons.
     ///
-    /// [`Keys`]: crate::Keys
+    /// [`Keys`]: crate::keys::Keys
     pub fn key_up(mut self, value: char) -> Self {
         self.key_channel.add_action(KeyAction::Up { value });
         self.add_mouse_pause();
@@ -595,7 +595,7 @@ impl ActionChainBuilder {
     /// Add a key down + key up action for each character in the specified string.
     /// See [`Keys`] for the codes for special keyboard buttons.
     ///
-    /// [`Keys`]: crate::Keys
+    /// [`Keys`]: crate::keys::Keys
     pub fn send_keys(mut self, text: &str) -> Self {
         for c in text.chars() {
             self = self.key_down(c).key_up(c)

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -217,7 +217,7 @@ impl PointerAction {
 /// A sequence containing [`Null` actions](NullAction).
 #[derive(Debug, Clone)]
 pub struct NullActions {
-    /// An identifier to distinguish this sequence from others.
+    /// A unique identifier to distinguish this input source from others.
     ///
     /// Choose a meaningful string as it may be useful for debugging.
     id: String,
@@ -227,6 +227,8 @@ pub struct NullActions {
 
 impl NullActions {
     /// Create a new NullActions sequence.
+    ///
+    /// The id can be any string but must uniquely identify this input source.
     pub fn new(id: String) -> Self {
         Self {
             id,
@@ -249,7 +251,7 @@ impl From<NullActions> for ActionSequence {
 /// A sequence containing [`Key` actions](KeyAction).
 #[derive(Debug, Clone)]
 pub struct KeyActions {
-    /// An identifier to distinguish this sequence from others.
+    /// A unique identifier to distinguish this input source from others.
     ///
     /// Choose a meaningful string as it may be useful for debugging.
     id: String,
@@ -259,6 +261,8 @@ pub struct KeyActions {
 
 impl KeyActions {
     /// Create a new KeyActions sequence.
+    ///
+    /// The id can be any string but must uniquely identify this input source.
     pub fn new(id: String) -> Self {
         Self {
             id,
@@ -281,7 +285,7 @@ impl From<KeyActions> for ActionSequence {
 /// A sequence containing [`Pointer` actions](PointerAction) for a mouse.
 #[derive(Debug, Clone)]
 pub struct MouseActions {
-    /// An identifier to distinguish this sequence from others.
+    /// A unique identifier to distinguish this input source from others.
     ///
     /// Choose a meaningful string as it may be useful for debugging.
     id: String,
@@ -291,6 +295,8 @@ pub struct MouseActions {
 
 impl MouseActions {
     /// Create a new `MouseActions` sequence.
+    ///
+    /// The id can be any string but must uniquely identify this input source.
     pub fn new(id: String) -> Self {
         Self {
             id,
@@ -316,7 +322,7 @@ impl From<MouseActions> for ActionSequence {
 /// A sequence containing [`Pointer` actions](PointerAction) for a pen device.
 #[derive(Debug, Clone)]
 pub struct PenActions {
-    /// An identifier to distinguish this sequence from others.
+    /// A unique identifier to distinguish this input source from others.
     ///
     /// Choose a meaningful string as it may be useful for debugging.
     id: String,
@@ -326,6 +332,8 @@ pub struct PenActions {
 
 impl PenActions {
     /// Create a new `PenActions` sequence.
+    ///
+    /// The id can be any string but must uniquely identify this input source.
     pub fn new(id: String) -> Self {
         Self {
             id,
@@ -351,7 +359,7 @@ impl From<PenActions> for ActionSequence {
 /// A sequence containing [`Pointer` actions](PointerAction) for a touch device.
 #[derive(Debug, Clone)]
 pub struct TouchActions {
-    /// An identifier to distinguish this sequence from others.
+    /// A unique identifier to distinguish this input source from others.
     ///
     /// Choose a meaningful string as it may be useful for debugging.
     id: String,
@@ -361,6 +369,8 @@ pub struct TouchActions {
 
 impl TouchActions {
     /// Create a new `TouchActions` sequence.
+    ///
+    /// The id can be any string but must uniquely identify this input source.
     pub fn new(id: String) -> Self {
         Self {
             id,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -3,7 +3,7 @@
 use crate::client::Client;
 use crate::elements::Element;
 #[cfg(doc)]
-use crate::keys::Key;
+use crate::key::Key;
 use std::fmt::Debug;
 use std::time::Duration;
 use webdriver::actions as WDActions;
@@ -110,20 +110,22 @@ pub enum PointerAction {
     Down {
         /// The mouse button index.
         ///
-        /// The following constants are provided:
-        /// - MOUSE_BUTTON_LEFT
-        /// - MOUSE_BUTTON_MIDDLE
-        /// - MOUSE_BUTTON_RIGHT
+        /// The following constants are provided, but any mouse index can be used
+        /// to represent the corresponding mouse button.
+        /// - [MOUSE_BUTTON_LEFT]
+        /// - [MOUSE_BUTTON_MIDDLE]
+        /// - [MOUSE_BUTTON_RIGHT]
         button: u64,
     },
     /// Pointer button up.
     Up {
         /// The mouse button index.
         ///
-        /// The following constants are provided:
-        /// - MOUSE_BUTTON_LEFT
-        /// - MOUSE_BUTTON_MIDDLE
-        /// - MOUSE_BUTTON_RIGHT
+        /// The following constants are provided, but any mouse index can be used
+        /// to represent the corresponding mouse button.
+        /// - [MOUSE_BUTTON_LEFT]
+        /// - [MOUSE_BUTTON_MIDDLE]
+        /// - [MOUSE_BUTTON_RIGHT]
         button: u64,
     },
     /// Move the pointer relative to the current position.
@@ -400,6 +402,9 @@ impl From<TouchActions> for ActionSequence {
 pub struct ActionSequence(pub(crate) WDActions::ActionSequence);
 
 /// A source capable of providing inputs for a browser action chain.
+///
+/// See [input source](https://www.w3.org/TR/webdriver1/#dfn-input-sources) in the
+/// WebDriver standard.
 ///
 /// Each sequence type implements `InputSource` which provides a `pause()` and a `then()`
 /// method. Each call to `pause()` or `then()` represents one tick for this sequence.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 //! WebDriver client implementation.
 
-use crate::actions::ActionChain;
+use crate::actions::{ActionSequence, Actions};
 use crate::elements::{Element, Form};
 use crate::error;
 use crate::session::{Cmd, Session, Task};
@@ -692,26 +692,31 @@ impl Client {
 
 /// [Actions](https://www.w3.org/TR/webdriver1/#actions)
 impl Client {
-    /// Perform the specified input actions.
+    /// Create a new Actions chain.
     ///
     /// ```ignore
-    /// use fantoccini::actions::ActionChain;
-    ///
-    /// let chain = ActionChain::builder()
-    ///     .click_element(element)
-    ///     .pause(Duration::from_secs(2))
-    ///     .send_keys("fantoccini")
-    ///     .build();
-    /// client.perform_actions(chain).await?;
+    /// let mouse_actions = MouseActions::new("mouse")
+    ///     .then(PointerAction::Down {
+    ///         button: MOUSE_BUTTON_LEFT,
+    ///     })
+    ///     .then(PointerAction::Move {
+    ///         duration: Some(Duration::from_secs(2)),
+    ///         origin: PointerOrigin::Pointer,
+    ///         x: 100,
+    ///         y: 0,
+    ///     })
+    ///     .then(PointerAction::Up {
+    ///         button: MOUSE_BUTTON_LEFT,
+    ///     });
+    /// client.actions(mouse_actions).perform().await?;
     /// ```
     ///
-    /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
-    /// WebDriver standard.
-    #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
-    pub async fn perform_actions(&mut self, actions: ActionChain) -> Result<(), error::CmdError> {
-        self.issue(WebDriverCommand::PerformActions(actions.into_params()))
-            .await?;
-        Ok(())
+    /// See the documentation for [`Actions`] for more information.
+    pub fn actions(&mut self, actions: impl Into<ActionSequence>) -> Actions {
+        Actions {
+            client: self.clone(),
+            sequences: vec![actions.into()],
+        }
     }
 
     /// Release all input actions.
@@ -721,6 +726,24 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Release Actions"))]
     pub async fn release_actions(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::ReleaseActions).await?;
+        Ok(())
+    }
+}
+
+impl Actions {
+    /// Perform the specified input actions.
+    ///
+    /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
+    pub async fn perform(mut self) -> Result<(), error::CmdError> {
+        let actions = webdriver::command::ActionsParameters {
+            actions: self.sequences.into_iter().map(|x| x.0).collect(),
+        };
+
+        self.client
+            .issue(WebDriverCommand::PerformActions(actions))
+            .await?;
         Ok(())
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use serde_json::Value as Json;
 use std::convert::{TryFrom, TryInto as _};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot};
-use webdriver::command::WebDriverCommand;
+use webdriver::command::{ActionsParameters, WebDriverCommand};
 use webdriver::common::{FrameId, ELEMENT_KEY};
 
 // Used only under `native-tls`
@@ -646,6 +646,30 @@ impl Client {
         };
 
         self.issue(WebDriverCommand::ExecuteAsyncScript(cmd)).await
+    }
+}
+
+/// [Actions](https://www.w3.org/TR/webdriver1/#actions)
+impl Client {
+    /// Perform the specified input actions.
+    ///
+    /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
+    pub async fn perform_actions(&self, actions: ActionsParameters) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::PerformActions(actions))
+            .await?;
+        Ok(())
+    }
+
+    /// Release all input actions.
+    ///
+    /// See [17.6 Release Actions](https://www.w3.org/TR/webdriver1/#release-actions) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Release Actions"))]
+    pub async fn release_actions(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::ReleaseActions).await?;
+        Ok(())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -155,7 +155,7 @@ impl Client {
     ///
     /// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Status"))]
-    pub async fn status(&self) -> Result<WebDriverStatus, error::CmdError> {
+    pub async fn status(&mut self) -> Result<WebDriverStatus, error::CmdError> {
         let res = self.issue(WebDriverCommand::Status).await?;
         let status: WebDriverStatus = serde_json::from_value(res)?;
         Ok(status)
@@ -166,7 +166,7 @@ impl Client {
     /// See [8.4 Get Timeouts](https://www.w3.org/TR/webdriver1/#get-timeouts) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Get Timeouts"))]
-    pub async fn get_timeouts(&self) -> Result<TimeoutConfiguration, error::CmdError> {
+    pub async fn get_timeouts(&mut self) -> Result<TimeoutConfiguration, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetTimeouts).await?;
         let timeouts: TimeoutConfiguration = serde_json::from_value(res)?;
         Ok(timeouts)
@@ -178,7 +178,7 @@ impl Client {
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Set Timeouts"))]
     pub async fn set_timeouts(
-        &self,
+        &mut self,
         timeouts: TimeoutConfiguration,
     ) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::SetTimeouts(timeouts.into()))
@@ -255,7 +255,7 @@ impl Client {
     ///
     /// See [9.6 Get Title](https://www.w3.org/TR/webdriver1/#dfn-get-title) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Title"))]
-    pub async fn title(&self) -> Result<String, error::CmdError> {
+    pub async fn title(&mut self) -> Result<String, error::CmdError> {
         let title = self.issue(WebDriverCommand::GetTitle).await?;
         if let Some(title) = title.as_str() {
             Ok(title.to_string())
@@ -376,7 +376,7 @@ impl Client {
     /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
-    pub async fn enter_frame(self, index: Option<u16>) -> Result<Client, error::CmdError> {
+    pub async fn enter_frame(mut self, index: Option<u16>) -> Result<Client, error::CmdError> {
         let params = webdriver::command::SwitchToFrameParameters {
             id: index.map(FrameId::Short),
         };
@@ -389,7 +389,7 @@ impl Client {
     /// See [10.6 Switch To Parent Frame](https://www.w3.org/TR/webdriver1/#switch-to-parent-frame)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Parent Frame"))]
-    pub async fn enter_parent_frame(self) -> Result<Client, error::CmdError> {
+    pub async fn enter_parent_frame(mut self) -> Result<Client, error::CmdError> {
         self.issue(WebDriverCommand::SwitchToParentFrame).await?;
         Ok(self)
     }
@@ -513,7 +513,7 @@ impl Client {
     ///
     /// See [10.7.3 Maximize Window](https://www.w3.org/TR/webdriver1/#dfn-maximize-window) of the
     /// WebDriver standard.
-    pub async fn maximize_window(&self) -> Result<(), error::CmdError> {
+    pub async fn maximize_window(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::MaximizeWindow).await?;
         Ok(())
     }
@@ -522,7 +522,7 @@ impl Client {
     ///
     /// See [10.7.4 Minimize Window](https://www.w3.org/TR/webdriver1/#dfn-minimize-window) of the
     /// WebDriver standard.
-    pub async fn minimize_window(&self) -> Result<(), error::CmdError> {
+    pub async fn minimize_window(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::MinimizeWindow).await?;
         Ok(())
     }
@@ -531,7 +531,7 @@ impl Client {
     ///
     /// See [10.7.5 Fullscreen Window](https://www.w3.org/TR/webdriver1/#dfn-fullscreen-window) of the
     /// WebDriver standard.
-    pub async fn fullscreen_window(&self) -> Result<(), error::CmdError> {
+    pub async fn fullscreen_window(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::FullscreenWindow).await?;
         Ok(())
     }
@@ -697,7 +697,7 @@ impl Client {
     /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
-    pub async fn perform_actions(&self, actions: ActionChain) -> Result<(), error::CmdError> {
+    pub async fn perform_actions(&mut self, actions: ActionChain) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::PerformActions(actions.into()))
             .await?;
         Ok(())
@@ -708,7 +708,7 @@ impl Client {
     /// See [17.6 Release Actions](https://www.w3.org/TR/webdriver1/#release-actions) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Release Actions"))]
-    pub async fn release_actions(&self) -> Result<(), error::CmdError> {
+    pub async fn release_actions(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::ReleaseActions).await?;
         Ok(())
     }
@@ -721,7 +721,7 @@ impl Client {
     /// See [18.1 Dismiss Alert](https://www.w3.org/TR/webdriver1/#dismiss-alert) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Dismiss Alert"))]
-    pub async fn dismiss_alert(&self) -> Result<(), error::CmdError> {
+    pub async fn dismiss_alert(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DismissAlert).await?;
         Ok(())
     }
@@ -731,7 +731,7 @@ impl Client {
     /// See [18.2 Accept Alert](https://www.w3.org/TR/webdriver1/#accept-alert) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Accept Alert"))]
-    pub async fn accept_alert(&self) -> Result<(), error::CmdError> {
+    pub async fn accept_alert(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::AcceptAlert).await?;
         Ok(())
     }
@@ -741,7 +741,7 @@ impl Client {
     /// See [18.3 Get Alert Text](https://www.w3.org/TR/webdriver1/#get-alert-text) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Alert Text"))]
-    pub async fn get_alert_text(&self) -> Result<String, error::CmdError> {
+    pub async fn get_alert_text(&mut self) -> Result<String, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetAlertText).await?;
         if let Some(v) = res.as_str() {
             Ok(v.to_string())
@@ -755,7 +755,7 @@ impl Client {
     /// See [18.4 Send Alert Text](https://www.w3.org/TR/webdriver1/#send-alert-text) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Send Alert Text"))]
-    pub async fn send_alert_text(&self, text: &str) -> Result<(), error::CmdError> {
+    pub async fn send_alert_text(&mut self, text: &str) -> Result<(), error::CmdError> {
         let params = SendKeysParameters {
             text: text.to_string(),
         };

--- a/src/client.rs
+++ b/src/client.rs
@@ -694,6 +694,18 @@ impl Client {
 impl Client {
     /// Perform the specified input actions.
     ///
+    /// Example:
+    /// ```no_run
+    /// use fantoccini::actions::ActionChain;
+    ///
+    /// let chain = ActionChain::builder()
+    ///     .click_element(element)
+    ///     .pause(Duration::from_secs(2))
+    ///     .send_keys("fantoccini")
+    ///     .build();
+    /// client.perform_actions(chain).await?;
+    /// ```
+    ///
     /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,13 +4,13 @@ use crate::elements::{Element, Form};
 use crate::error;
 use crate::session::{Cmd, Session, Task};
 use crate::wait::Wait;
-use crate::wd::{Capabilities, Locator, NewWindowType, WindowHandle};
+use crate::wd::{Capabilities, Locator, NewWindowType, WebDriverStatus, WindowHandle};
 use hyper::{client::connect, Method};
 use serde_json::Value as Json;
 use std::convert::{TryFrom, TryInto as _};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot};
-use webdriver::command::{ActionsParameters, WebDriverCommand};
+use webdriver::command::{ActionsParameters, TimeoutsParameters, WebDriverCommand};
 use webdriver::common::{FrameId, ELEMENT_KEY};
 
 // Used only under `native-tls`
@@ -145,6 +145,40 @@ impl Client {
 }
 
 // NOTE: new impl block to keep related methods together.
+
+/// [Sessions](https://www.w3.org/TR/webdriver1/#sessions)
+impl Client {
+    /// Get the WebDriver status.
+    ///
+    /// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Status"))]
+    pub async fn status(&self) -> Result<WebDriverStatus, error::CmdError> {
+        let res = self.issue(WebDriverCommand::Status).await?;
+        let status: WebDriverStatus = serde_json::from_value(res)?;
+        Ok(status)
+    }
+
+    /// Get the timeouts for the current session.
+    ///
+    /// See [8.4 Get Timeouts](https://www.w3.org/TR/webdriver1/#get-timeouts) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Timeouts"))]
+    pub async fn get_timeouts(&self) -> Result<TimeoutsParameters, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetTimeouts).await?;
+        let timeouts: TimeoutsParameters = serde_json::from_value(res)?;
+        Ok(timeouts)
+    }
+
+    /// Set the timeouts for the current session.
+    ///
+    /// See [8.5 Set Timeouts](https://www.w3.org/TR/webdriver1/#set-timeouts) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Set Timeouts"))]
+    pub async fn set_timeouts(&self, params: TimeoutsParameters) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::SetTimeouts(params)).await?;
+        Ok(())
+    }
+}
 
 /// [Navigation](https://www.w3.org/TR/webdriver1/#navigation)
 impl Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -177,7 +177,8 @@ impl Client {
     /// See [8.5 Set Timeouts](https://www.w3.org/TR/webdriver1/#set-timeouts) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Set Timeouts"))]
-    pub async fn set_timeouts(
+    #[cfg_attr(docsrs, doc(alias = "Update Timeouts"))]
+    pub async fn update_timeouts(
         &mut self,
         timeouts: TimeoutConfiguration,
     ) -> Result<(), error::CmdError> {
@@ -707,7 +708,7 @@ impl Client {
     ///     .then(PointerAction::Up {
     ///         button: MOUSE_BUTTON_LEFT,
     ///     });
-    /// client.perform_actions(mouse_actions.into()).await?;
+    /// client.perform_actions(mouse_actions).await?;
     /// ```
     ///
     /// See the documentation for [`Actions`] for more information.
@@ -716,9 +717,12 @@ impl Client {
     /// See [17.5 Perform Actions](https://www.w3.org/TR/webdriver1/#perform-actions) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
-    pub async fn perform_actions(&mut self, actions: Actions) -> Result<(), error::CmdError> {
+    pub async fn perform_actions(
+        &mut self,
+        actions: impl Into<Actions>,
+    ) -> Result<(), error::CmdError> {
         let params = webdriver::command::ActionsParameters {
-            actions: actions.sequences.into_iter().map(|x| x.0).collect(),
+            actions: actions.into().sequences.into_iter().map(|x| x.0).collect(),
         };
 
         self.issue(WebDriverCommand::PerformActions(params)).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -192,6 +192,15 @@ impl Client {
         Ok(())
     }
 
+    /// Go forward to the next page.
+    ///
+    /// See [9.4 Forward](https://www.w3.org/TR/webdriver1/#dfn-forward) of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Forward"))]
+    pub async fn forward(&mut self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::GoForward).await?;
+        Ok(())
+    }
+
     /// Refresh the current previous page.
     ///
     /// See [9.5 Refresh](https://www.w3.org/TR/webdriver1/#dfn-refresh) of the WebDriver standard.
@@ -199,6 +208,19 @@ impl Client {
     pub async fn refresh(&mut self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::Refresh).await?;
         Ok(())
+    }
+
+    /// Get the current page title.
+    ///
+    /// See [9.6 Get Title](https://www.w3.org/TR/webdriver1/#dfn-get-title) of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Title"))]
+    pub async fn title(&self) -> Result<String, error::CmdError> {
+        let title = self.issue(WebDriverCommand::GetTitle).await?;
+        if let Some(title) = title.as_str() {
+            Ok(title.to_string())
+        } else {
+            Err(error::CmdError::NotW3C(title))
+        }
     }
 }
 
@@ -444,6 +466,33 @@ impl Client {
     pub async fn get_window_position(&mut self) -> Result<(u64, u64), error::CmdError> {
         let (x, y, _, _) = self.get_window_rect().await?;
         Ok((x, y))
+    }
+
+    /// Maximize the current window.
+    ///
+    /// See [10.7.3 Maximize Window](https://www.w3.org/TR/webdriver1/#dfn-maximize-window) of the
+    /// WebDriver standard.
+    pub async fn maximize_window(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::MaximizeWindow).await?;
+        Ok(())
+    }
+
+    /// Minimize the current window.
+    ///
+    /// See [10.7.4 Minimize Window](https://www.w3.org/TR/webdriver1/#dfn-minimize-window) of the
+    /// WebDriver standard.
+    pub async fn minimize_window(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::MinimizeWindow).await?;
+        Ok(())
+    }
+
+    /// Make the current window fullscreen.
+    ///
+    /// See [10.7.5 Fullscreen Window](https://www.w3.org/TR/webdriver1/#dfn-fullscreen-window) of the
+    /// WebDriver standard.
+    pub async fn fullscreen_window(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::FullscreenWindow).await?;
+        Ok(())
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -694,7 +694,7 @@ impl Client {
 impl Client {
     /// Perform the specified input actions.
     ///
-    /// ```no_run
+    /// ```ignore
     /// use fantoccini::actions::ActionChain;
     ///
     /// let chain = ActionChain::builder()

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,9 @@ use serde_json::Value as Json;
 use std::convert::{TryFrom, TryInto as _};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot};
-use webdriver::command::{ActionsParameters, TimeoutsParameters, WebDriverCommand};
+use webdriver::command::{
+    ActionsParameters, SendKeysParameters, TimeoutsParameters, WebDriverCommand,
+};
 use webdriver::common::{FrameId, ELEMENT_KEY};
 
 // Used only under `native-tls`
@@ -703,6 +705,56 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Release Actions"))]
     pub async fn release_actions(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::ReleaseActions).await?;
+        Ok(())
+    }
+}
+
+/// [User Prompts](https://www.w3.org/TR/webdriver1/#user-prompts)
+impl Client {
+    /// Dismiss the active alert, if there is one.
+    ///
+    /// See [18.1 Dismiss Alert](https://www.w3.org/TR/webdriver1/#dismiss-alert) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Dismiss Alert"))]
+    pub async fn dismiss_alert(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::DismissAlert).await?;
+        Ok(())
+    }
+
+    /// Accept the active alert, if there is one.
+    ///
+    /// See [18.2 Accept Alert](https://www.w3.org/TR/webdriver1/#accept-alert) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Accept Alert"))]
+    pub async fn accept_alert(&self) -> Result<(), error::CmdError> {
+        self.issue(WebDriverCommand::AcceptAlert).await?;
+        Ok(())
+    }
+
+    /// Get the text of the active alert, if there is one.
+    ///
+    /// See [18.3 Get Alert Text](https://www.w3.org/TR/webdriver1/#get-alert-text) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Alert Text"))]
+    pub async fn get_alert_text(&self) -> Result<String, error::CmdError> {
+        let res = self.issue(WebDriverCommand::GetAlertText).await?;
+        if let Some(v) = res.as_str() {
+            Ok(v.to_string())
+        } else {
+            Err(error::CmdError::NotW3C(res))
+        }
+    }
+
+    /// Send the specified text to the active alert, if there is one.
+    ///
+    /// See [18.4 Send Alert Text](https://www.w3.org/TR/webdriver1/#send-alert-text) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Send Alert Text"))]
+    pub async fn send_alert_text(&self, text: &str) -> Result<(), error::CmdError> {
+        let params = SendKeysParameters {
+            text: text.to_string(),
+        };
+        self.issue(WebDriverCommand::SendAlertText(params)).await?;
         Ok(())
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -181,7 +181,7 @@ impl Client {
         &mut self,
         timeouts: TimeoutConfiguration,
     ) -> Result<(), error::CmdError> {
-        self.issue(WebDriverCommand::SetTimeouts(timeouts.into()))
+        self.issue(WebDriverCommand::SetTimeouts(timeouts.into_params()))
             .await?;
         Ok(())
     }
@@ -257,8 +257,8 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Get Title"))]
     pub async fn title(&mut self) -> Result<String, error::CmdError> {
         let title = self.issue(WebDriverCommand::GetTitle).await?;
-        if let Some(title) = title.as_str() {
-            Ok(title.to_string())
+        if let Json::String(s) = title {
+            Ok(s)
         } else {
             Err(error::CmdError::NotW3C(title))
         }
@@ -709,7 +709,7 @@ impl Client {
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
     pub async fn perform_actions(&mut self, actions: ActionChain) -> Result<(), error::CmdError> {
-        self.issue(WebDriverCommand::PerformActions(actions.into()))
+        self.issue(WebDriverCommand::PerformActions(actions.into_params()))
             .await?;
         Ok(())
     }
@@ -754,8 +754,8 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Get Alert Text"))]
     pub async fn get_alert_text(&mut self) -> Result<String, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetAlertText).await?;
-        if let Some(v) = res.as_str() {
-            Ok(v.to_string())
+        if let Json::String(s) = res {
+            Ok(s)
         } else {
             Err(error::CmdError::NotW3C(res))
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -694,7 +694,6 @@ impl Client {
 impl Client {
     /// Perform the specified input actions.
     ///
-    /// Example:
     /// ```no_run
     /// use fantoccini::actions::ActionChain;
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -313,7 +313,7 @@ impl Client {
     /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
-    pub async fn enter_frame(mut self, index: Option<u16>) -> Result<Client, error::CmdError> {
+    pub async fn enter_frame(self, index: Option<u16>) -> Result<Client, error::CmdError> {
         let params = webdriver::command::SwitchToFrameParameters {
             id: index.map(FrameId::Short),
         };
@@ -326,7 +326,7 @@ impl Client {
     /// See [10.6 Switch To Parent Frame](https://www.w3.org/TR/webdriver1/#switch-to-parent-frame)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Parent Frame"))]
-    pub async fn enter_parent_frame(mut self) -> Result<Client, error::CmdError> {
+    pub async fn enter_parent_frame(self) -> Result<Client, error::CmdError> {
         self.issue(WebDriverCommand::SwitchToParentFrame).await?;
         Ok(self)
     }

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -18,10 +18,22 @@ pub struct AddCookieParametersWrapper<'a> {
     pub cookie: &'a AddCookieParameters,
 }
 
+/// The SameSite parameter for cookies.
+///
+/// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+/// for more details.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub(crate) enum SameSite {
+    /// Cookies will only be sent in a first-party context and not be sent along with
+    /// requests initiated by third party websites.
     Strict,
+    /// Cookies are not sent on normal cross-site subrequests (for example to load images
+    /// or frames into a third party site), but are sent when a user is navigating to the
+    /// origin site (i.e., when following a link).
     Lax,
+    /// Cookies will be sent in all contexts, i.e. in responses to both first-party and
+    /// cross-origin requests. If SameSite=None is set, the cookie Secure attribute must
+    /// also be set (or the cookie will be blocked).
     None,
 }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -4,13 +4,50 @@ use crate::wd::Locator;
 use crate::{error, Client};
 use serde::Serialize;
 use serde_json::Value as Json;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use webdriver::command::WebDriverCommand;
 use webdriver::common::FrameId;
 use webdriver::error::WebDriverError;
 
 /// An element id.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct ElementId(pub String);
+///
+/// See [11. Elements](https://www.w3.org/TR/webdriver1/#elements) of the
+/// WebDriver standard.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ElementId(String);
+
+impl Display for ElementId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for ElementId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for ElementId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ElementId> for String {
+    fn from(id: ElementId) -> Self {
+        id.0
+    }
+}
+
+impl From<String> for ElementId {
+    fn from(s: String) -> Self {
+        ElementId(s)
+    }
+}
 
 /// A single DOM element on the current page.
 ///
@@ -135,7 +172,6 @@ impl Element {
         let cmd = WebDriverCommand::IsSelected(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
-            Json::Null => Ok(false),
             v => Err(error::CmdError::NotW3C(v)),
         }
     }
@@ -148,7 +184,6 @@ impl Element {
         let cmd = WebDriverCommand::IsEnabled(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
-            Json::Null => Ok(false),
             v => Err(error::CmdError::NotW3C(v)),
         }
     }
@@ -161,7 +196,6 @@ impl Element {
         let cmd = WebDriverCommand::IsDisplayed(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
-            Json::Null => Ok(false),
             v => Err(error::CmdError::NotW3C(v)),
         }
     }
@@ -217,7 +251,6 @@ impl Element {
         let cmd = WebDriverCommand::GetCSSValue(self.element.clone(), prop.to_string());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(v),
-            Json::Null => Ok(String::new()),
             v => Err(error::CmdError::NotW3C(v)),
         }
     }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -59,7 +59,10 @@ impl Element {
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
     pub async fn enter_frame(self) -> Result<Client, error::CmdError> {
-        let Self { client, element } = self;
+        let Self {
+            mut client,
+            element,
+        } = self;
         let params = webdriver::command::SwitchToFrameParameters {
             id: Some(FrameId::Element(element)),
         };
@@ -124,7 +127,7 @@ impl Element {
     ///
     /// See [13.1 Is Element Selected](https://www.w3.org/TR/webdriver1/#is-element-selected)
     /// of the WebDriver standard.
-    pub async fn is_selected(&self) -> Result<bool, error::CmdError> {
+    pub async fn is_selected(&mut self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsSelected(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -137,7 +140,7 @@ impl Element {
     ///
     /// See [13.8 Is Element Enabled](https://www.w3.org/TR/webdriver1/#is-element-enabled)
     /// of the WebDriver standard.
-    pub async fn is_enabled(&self) -> Result<bool, error::CmdError> {
+    pub async fn is_enabled(&mut self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsEnabled(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -150,7 +153,7 @@ impl Element {
     ///
     /// See [Element Displayedness](https://www.w3.org/TR/webdriver1/#element-displayedness)
     /// of the WebDriver standard.
-    pub async fn is_displayed(&self) -> Result<bool, error::CmdError> {
+    pub async fn is_displayed(&mut self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsDisplayed(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -304,7 +307,7 @@ impl Element {
     /// See [14.1 Element Click](https://www.w3.org/TR/webdriver1/#element-click) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Element Click"))]
-    pub async fn click(self) -> Result<Client, error::CmdError> {
+    pub async fn click(mut self) -> Result<Client, error::CmdError> {
         let cmd = WebDriverCommand::ElementClick(self.element);
         let r = self.client.issue(cmd).await?;
         if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
@@ -486,7 +489,7 @@ impl Form {
     /// Submit this form using the button matched by the given selector.
     ///
     /// `false` is returned if a matching button was not found.
-    pub async fn submit_with(self, button: Locator<'_>) -> Result<Client, error::CmdError> {
+    pub async fn submit_with(mut self, button: Locator<'_>) -> Result<Client, error::CmdError> {
         let locator = WebDriverCommand::FindElementElement(self.form, button.into_parameters());
         let res = self.client.issue(locator).await?;
         let submit = self.client.parse_lookup(res)?;
@@ -523,7 +526,7 @@ impl Form {
     ///
     /// Note that since no button is actually clicked, the `name=value` pair for the submit button
     /// will not be submitted. This can be circumvented by using `submit_sneaky` instead.
-    pub async fn submit_direct(self) -> Result<Client, error::CmdError> {
+    pub async fn submit_direct(mut self) -> Result<Client, error::CmdError> {
         let mut args = vec![via_json!(&self.form)];
         self.client.fixup_elements(&mut args);
         // some sites are silly, and name their submit button "submit". this ends up overwriting
@@ -554,7 +557,11 @@ impl Form {
     /// However, it will *also* inject a hidden input element on the page that carries the given
     /// `field=value` mapping. This allows you to emulate the form data as it would have been *if*
     /// the submit button was indeed clicked.
-    pub async fn submit_sneaky(self, field: &str, value: &str) -> Result<Client, error::CmdError> {
+    pub async fn submit_sneaky(
+        mut self,
+        field: &str,
+        value: &str,
+    ) -> Result<Client, error::CmdError> {
         let mut args = vec![via_json!(&self.form), Json::from(field), Json::from(value)];
         self.client.fixup_elements(&mut args);
         let cmd = webdriver::command::JavascriptCommandParameters {

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -244,12 +244,14 @@ impl Element {
         }
     }
 
-    /// Look up a CSS property for this element by name.
+    /// Look up the [`computed value`] of a CSS property for this element by name.
     ///
     /// `Ok(String::new())` is returned if the the given CSS property is not found.
     ///
     /// See [13.4 Get Element CSS Value](https://www.w3.org/TR/webdriver1/#get-element-css-value)
     /// of the WebDriver standard.
+    ///
+    /// [`computed value`]: https://drafts.csswg.org/css-cascade-4/#computed-value
     #[cfg_attr(docsrs, doc(alias = "Get Element CSS Value"))]
     pub async fn css_value(&mut self, prop: &str) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetCSSValue(self.element.clone(), prop.to_string());

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -99,6 +99,32 @@ impl Element {
 
 /// [Element State](https://www.w3.org/TR/webdriver1/#element-state)
 impl Element {
+    /// Return true if the element is currently selected.
+    ///
+    /// See [13.1 Is Element Selected](https://www.w3.org/TR/webdriver1/#is-element-selected)
+    /// of the WebDriver standard.
+    pub async fn is_selected(&self) -> Result<bool, error::CmdError> {
+        let cmd = WebDriverCommand::IsSelected(self.element.clone());
+        match self.client.issue(cmd).await? {
+            Json::Bool(v) => Ok(v),
+            Json::Null => Ok(false),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Return true if the element is currently enabled.
+    ///
+    /// See [13.8 Is Element Enabled](https://www.w3.org/TR/webdriver1/#is-element-enabled)
+    /// of the WebDriver standard.
+    pub async fn is_enabled(&self) -> Result<bool, error::CmdError> {
+        let cmd = WebDriverCommand::IsEnabled(self.element.clone());
+        match self.client.issue(cmd).await? {
+            Json::Bool(v) => Ok(v),
+            Json::Null => Ok(false),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
     /// Look up an [attribute] value for this element by name.
     ///
     /// `Ok(None)` is returned if the element does not have the given attribute.
@@ -136,13 +162,42 @@ impl Element {
         }
     }
 
-    /// Retrieve the text contents of this elment.
+    /// Look up a CSS property for this element by name.
+    ///
+    /// `Ok(String::new())` is returned if the the given CSS property is not found.
+    ///
+    /// See [13.4 Get Element CSS Value](https://www.w3.org/TR/webdriver1/#get-element-css-value)
+    /// of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Element CSS Value"))]
+    pub async fn css_value(&mut self, prop: &str) -> Result<String, error::CmdError> {
+        let cmd = WebDriverCommand::GetCSSValue(self.element.clone(), prop.to_string());
+        match self.client.issue(cmd).await? {
+            Json::String(v) => Ok(v),
+            Json::Null => Ok(String::new()),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Retrieve the text contents of this element.
     ///
     /// See [13.5 Get Element Text](https://www.w3.org/TR/webdriver1/#get-element-text)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Element Text"))]
     pub async fn text(&mut self) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetElementText(self.element.clone());
+        match self.client.issue(cmd).await? {
+            Json::String(v) => Ok(v),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
+    /// Retrieve the tag name of this element.
+    ///
+    /// See [13.6 Get Element Tag Name](https://www.w3.org/TR/webdriver1/#get-element-tag-name)
+    /// of the WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Element Tag Name"))]
+    pub async fn tag_name(&mut self) -> Result<String, error::CmdError> {
+        let cmd = WebDriverCommand::GetElementTagName(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(v),
             v => Err(error::CmdError::NotW3C(v)),

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -217,6 +217,44 @@ impl Element {
         }
     }
 
+    /// Gets the x, y, width, and height properties of the current element.
+    ///
+    /// See [13.7 Get Element Rect](https://www.w3.org/TR/webdriver1/#dfn-get-element-rect) of the
+    /// WebDriver standard.
+    #[cfg_attr(docsrs, doc(alias = "Get Element Rect"))]
+    pub async fn get_element_rect(&mut self) -> Result<(i64, i64, u64, u64), error::CmdError> {
+        match self
+            .client
+            .issue(WebDriverCommand::GetElementRect(self.element.clone()))
+            .await?
+        {
+            Json::Object(mut obj) => {
+                let x = match obj.remove("x").and_then(|x| x.as_i64()) {
+                    Some(x) => x,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let y = match obj.remove("y").and_then(|y| y.as_i64()) {
+                    Some(y) => y,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let width = match obj.remove("width").and_then(|width| width.as_u64()) {
+                    Some(width) => width,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                let height = match obj.remove("height").and_then(|height| height.as_u64()) {
+                    Some(height) => height,
+                    None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
+                };
+
+                Ok((x, y, width, height))
+            }
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
     /// Retrieve the HTML contents of this element.
     ///
     /// `inner` dictates whether the wrapping node's HTML is excluded or not. For example, take the

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -194,6 +194,11 @@ impl Element {
         let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(Some(v)),
+            Json::Bool(b) => {
+                // NOTE: boolean properties such as "checked" seem to be returned as boolean
+                //       values rather than strings.
+                Ok(Some(b.to_string()))
+            }
             Json::Null => Ok(None),
             v => Err(error::CmdError::NotW3C(v)),
         }
@@ -246,19 +251,19 @@ impl Element {
     /// See [13.7 Get Element Rect](https://www.w3.org/TR/webdriver1/#dfn-get-element-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Element Rect"))]
-    pub async fn get_element_rect(&mut self) -> Result<(i64, i64, u64, u64), error::CmdError> {
+    pub async fn get_element_rect(&mut self) -> Result<(f64, f64, u64, u64), error::CmdError> {
         match self
             .client
             .issue(WebDriverCommand::GetElementRect(self.element.clone()))
             .await?
         {
             Json::Object(mut obj) => {
-                let x = match obj.remove("x").and_then(|x| x.as_i64()) {
+                let x = match obj.remove("x").and_then(|x| x.as_f64()) {
                     Some(x) => x,
                     None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
                 };
 
-                let y = match obj.remove("y").and_then(|y| y.as_i64()) {
+                let y = match obj.remove("y").and_then(|y| y.as_f64()) {
                     Some(y) => y,
                     None => return Err(error::CmdError::NotW3C(Json::Object(obj))),
                 };

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -244,14 +244,14 @@ impl Element {
         }
     }
 
-    /// Look up the [`computed value`] of a CSS property for this element by name.
+    /// Look up the [computed value] of a CSS property for this element by name.
     ///
     /// `Ok(String::new())` is returned if the the given CSS property is not found.
     ///
     /// See [13.4 Get Element CSS Value](https://www.w3.org/TR/webdriver1/#get-element-css-value)
     /// of the WebDriver standard.
     ///
-    /// [`computed value`]: https://drafts.csswg.org/css-cascade-4/#computed-value
+    /// [computed value]: https://drafts.csswg.org/css-cascade-4/#computed-value
     #[cfg_attr(docsrs, doc(alias = "Get Element CSS Value"))]
     pub async fn css_value(&mut self, prop: &str) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetCSSValue(self.element.clone(), prop.to_string());

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -17,10 +17,31 @@ use webdriver::error::WebDriverError;
 pub struct Element {
     /// The high-level WebDriver client, for sending commands.
     #[serde(skip_serializing)]
-    pub client: Client,
+    pub(crate) client: Client,
     /// The encapsulated WebElement struct.
     #[serde(flatten)]
-    pub element: webdriver::common::WebElement,
+    pub(crate) element: webdriver::common::WebElement,
+}
+
+impl Element {
+    /// Construct an `Element` with the specified element id.
+    /// The element id is the id given by the webdriver.
+    pub fn from_element_id(client: Client, element_id: String) -> Self {
+        Self {
+            client,
+            element: webdriver::common::WebElement(element_id),
+        }
+    }
+
+    /// Get back the [`Client`] hosting this `Element`.
+    pub fn client(self) -> Client {
+        self.client
+    }
+
+    /// Get the element id as given by the webdriver.
+    pub fn element_id(&self) -> &str {
+        &self.element.0
+    }
 }
 
 /// An HTML form on the current page.

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -125,6 +125,19 @@ impl Element {
         }
     }
 
+    /// Return true if the element is currently displayed.
+    ///
+    /// See [Element Displayedness](https://www.w3.org/TR/webdriver1/#element-displayedness)
+    /// of the WebDriver standard.
+    pub async fn is_displayed(&self) -> Result<bool, error::CmdError> {
+        let cmd = WebDriverCommand::IsDisplayed(self.element.clone());
+        match self.client.issue(cmd).await? {
+            Json::Bool(v) => Ok(v),
+            Json::Null => Ok(false),
+            v => Err(error::CmdError::NotW3C(v)),
+        }
+    }
+
     /// Look up an [attribute] value for this element by name.
     ///
     /// `Ok(None)` is returned if the element does not have the given attribute.

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -10,26 +10,30 @@ use webdriver::command::WebDriverCommand;
 use webdriver::common::FrameId;
 use webdriver::error::WebDriverError;
 
-/// An element id.
+/// Web element reference.
 ///
-/// See [11. Elements](https://www.w3.org/TR/webdriver1/#elements) of the
-/// WebDriver standard.
+/// > Each element has an associated web element reference that uniquely identifies the element
+/// > across all browsing contexts. The web element reference for every element representing the
+/// > same element must be the same. It must be a string, and should be the result of generating
+/// > a UUID.
+///
+/// See [11. Elements](https://www.w3.org/TR/webdriver1/#elements) of the WebDriver standard.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ElementId(String);
+pub struct ElementRef(String);
 
-impl Display for ElementId {
+impl Display for ElementRef {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl AsRef<str> for ElementId {
+impl AsRef<str> for ElementRef {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl Deref for ElementId {
+impl Deref for ElementRef {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -37,15 +41,15 @@ impl Deref for ElementId {
     }
 }
 
-impl From<ElementId> for String {
-    fn from(id: ElementId) -> Self {
+impl From<ElementRef> for String {
+    fn from(id: ElementRef) -> Self {
         id.0
     }
 }
 
-impl From<String> for ElementId {
+impl From<String> for ElementRef {
     fn from(s: String) -> Self {
-        ElementId(s)
+        ElementRef(s)
     }
 }
 
@@ -67,7 +71,7 @@ pub struct Element {
 impl Element {
     /// Construct an `Element` with the specified element id.
     /// The element id is the id given by the webdriver.
-    pub fn from_element_id(client: Client, element_id: ElementId) -> Self {
+    pub fn from_element_id(client: Client, element_id: ElementRef) -> Self {
         Self {
             client,
             element: webdriver::common::WebElement(element_id.0),
@@ -80,8 +84,8 @@ impl Element {
     }
 
     /// Get the element id as given by the webdriver.
-    pub fn element_id(&self) -> ElementId {
-        ElementId(self.element.0.clone())
+    pub fn element_id(&self) -> ElementRef {
+        ElementRef(self.element.0.clone())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,6 +89,14 @@ pub enum CmdError {
     /// ["no such window"]: https://www.w3.org/TR/webdriver/#dfn-no-such-window
     NoSuchWindow(WebDriver),
 
+    /// The requested alert does not exist.
+    ///
+    /// This variant lifts the ["no such alert"] error variant from `Standard` to simplify
+    /// checking for it in user code.
+    ///
+    /// ["no such alert"]: https://www.w3.org/TR/webdriver/#dfn-no-such-alert
+    NoSuchAlert(WebDriver),
+
     /// A bad URL was encountered during parsing.
     ///
     /// This normally happens if a link is clicked or the current URL is requested, but the URL in
@@ -150,14 +158,20 @@ impl CmdError {
     }
 
     pub(crate) fn from_webdriver_error(e: webdriver::WebDriverError) -> Self {
-        if let webdriver::WebDriverError {
-            error: webdriver::ErrorStatus::NoSuchElement,
-            ..
-        } = e
-        {
-            CmdError::NoSuchElement(WebDriver::from_upstream_error(e))
-        } else {
-            CmdError::Standard(WebDriver::from_upstream_error(e))
+        match e {
+            webdriver::WebDriverError {
+                error: webdriver::ErrorStatus::NoSuchElement,
+                ..
+            } => CmdError::NoSuchElement(WebDriver::from_upstream_error(e)),
+            webdriver::WebDriverError {
+                error: webdriver::ErrorStatus::NoSuchWindow,
+                ..
+            } => CmdError::NoSuchWindow(WebDriver::from_upstream_error(e)),
+            webdriver::WebDriverError {
+                error: webdriver::ErrorStatus::NoSuchAlert,
+                ..
+            } => CmdError::NoSuchAlert(WebDriver::from_upstream_error(e)),
+            _ => CmdError::Standard(WebDriver::from_upstream_error(e)),
         }
     }
 }
@@ -168,6 +182,7 @@ impl Error for CmdError {
             CmdError::Standard(..) => "webdriver returned error",
             CmdError::NoSuchElement(..) => "no element found matching selector",
             CmdError::NoSuchWindow(..) => "no window is currently selected",
+            CmdError::NoSuchAlert(..) => "no alert is currently visible",
             CmdError::BadUrl(..) => "bad url provided",
             CmdError::Failed(..) => "webdriver could not be reached",
             CmdError::Lost(..) => "webdriver connection lost",
@@ -184,7 +199,8 @@ impl Error for CmdError {
         match *self {
             CmdError::Standard(ref e)
             | CmdError::NoSuchElement(ref e)
-            | CmdError::NoSuchWindow(ref e) => Some(e),
+            | CmdError::NoSuchWindow(ref e)
+            | CmdError::NoSuchAlert(ref e) => Some(e),
             CmdError::BadUrl(ref e) => Some(e),
             CmdError::Failed(ref e) => Some(e),
             CmdError::Lost(ref e) => Some(e),
@@ -205,7 +221,8 @@ impl fmt::Display for CmdError {
         match *self {
             CmdError::Standard(ref e)
             | CmdError::NoSuchElement(ref e)
-            | CmdError::NoSuchWindow(ref e) => write!(f, "{}", e),
+            | CmdError::NoSuchWindow(ref e)
+            | CmdError::NoSuchAlert(ref e) => write!(f, "{}", e),
             CmdError::BadUrl(ref e) => write!(f, "{}", e),
             CmdError::Failed(ref e) => write!(f, "{}", e),
             CmdError::Lost(ref e) => write!(f, "{}", e),

--- a/src/error.rs
+++ b/src/error.rs
@@ -248,7 +248,7 @@ impl From<serde_json::Error> for CmdError {
 /// Error of attempting to create an invalid [`WindowHandle`] from a
 /// [`"current"` string][1].
 ///
-/// [`WindowHandle`]: crate::WindowHandle
+/// [`WindowHandle`]: crate::wd::WindowHandle
 /// [1]: https://www.w3.org/TR/webdriver/#dfn-window-handles
 #[derive(Clone, Copy, Debug)]
 pub struct InvalidWindowHandle;

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::{Add, AddAssign};
 
 /// Key codes for use with Actions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Key {
     /// Null
     Null,
@@ -185,7 +185,7 @@ impl From<Key> for char {
 
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", char::from(self.clone()))
+        write!(f, "{}", char::from(*self))
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,181 @@
+//! Key codes for use with Actions.
+
+/// Key codes for use with Actions.
+#[derive(Debug)]
+pub enum Keys {
+    /// Null
+    Null,
+    /// Cancel
+    Cancel,
+    /// Help
+    Help,
+    /// Backspace key
+    Backspace,
+    /// Tab key
+    Tab,
+    /// Clear
+    Clear,
+    /// Return key
+    Return,
+    /// Enter key
+    Enter,
+    /// Shift key
+    Shift,
+    /// Control key
+    Control,
+    /// Alt key
+    Alt,
+    /// Pause key
+    Pause,
+    /// Escape key
+    Escape,
+    /// Space bar
+    Space,
+    /// Page Up key
+    PageUp,
+    /// Page Down key
+    PageDown,
+    /// End key
+    End,
+    /// Home key
+    Home,
+    /// Left arrow key
+    Left,
+    /// Up arrow key
+    Up,
+    /// Right arrow key
+    Right,
+    /// Down arrow key
+    Down,
+    /// Insert key
+    Insert,
+    /// Delete key
+    Delete,
+    /// Semicolon key
+    Semicolon,
+    /// Equals key
+    Equals,
+    /// Numpad 0 key
+    NumPad0,
+    /// Numpad 1 key
+    NumPad1,
+    /// Numpad 2 key
+    NumPad2,
+    /// Numpad 3 key
+    NumPad3,
+    /// Numpad 4 key
+    NumPad4,
+    /// Numpad 5 key
+    NumPad5,
+    /// Numpad 6 key
+    NumPad6,
+    /// Numpad 7 key
+    NumPad7,
+    /// Numpad 8 key
+    NumPad8,
+    /// Numpad 9 key
+    NumPad9,
+    /// Multiply key
+    Multiply,
+    /// Add key
+    Add,
+    /// Separator key
+    Separator,
+    /// Subtract key
+    Subtract,
+    /// Decimal key
+    Decimal,
+    /// Divide key
+    Divide,
+    /// F1 key
+    F1,
+    /// F2 key
+    F2,
+    /// F3 key
+    F3,
+    /// F4 key
+    F4,
+    /// F5 key
+    F5,
+    /// F6 key
+    F6,
+    /// F7 key
+    F7,
+    /// F8 key
+    F8,
+    /// F9 key
+    F9,
+    /// F10 key
+    F10,
+    /// F11 key
+    F11,
+    /// F12 key
+    F12,
+    /// Meta key
+    Meta,
+    /// Command key
+    Command,
+}
+
+impl From<Keys> for char {
+    fn from(k: Keys) -> char {
+        match k {
+            Keys::Null => '\u{e000}',
+            Keys::Cancel => '\u{e001}',
+            Keys::Help => '\u{e002}',
+            Keys::Backspace => '\u{e003}',
+            Keys::Tab => '\u{e004}',
+            Keys::Clear => '\u{e005}',
+            Keys::Return => '\u{e006}',
+            Keys::Enter => '\u{e007}',
+            Keys::Shift => '\u{e008}',
+            Keys::Control => '\u{e009}',
+            Keys::Alt => '\u{e00a}',
+            Keys::Pause => '\u{e00b}',
+            Keys::Escape => '\u{e00c}',
+            Keys::Space => '\u{e00d}',
+            Keys::PageUp => '\u{e00e}',
+            Keys::PageDown => '\u{e00f}',
+            Keys::End => '\u{e010}',
+            Keys::Home => '\u{e011}',
+            Keys::Left => '\u{e012}',
+            Keys::Up => '\u{e013}',
+            Keys::Right => '\u{e014}',
+            Keys::Down => '\u{e015}',
+            Keys::Insert => '\u{e016}',
+            Keys::Delete => '\u{e017}',
+            Keys::Semicolon => '\u{e018}',
+            Keys::Equals => '\u{e019}',
+            Keys::NumPad0 => '\u{e01a}',
+            Keys::NumPad1 => '\u{e01b}',
+            Keys::NumPad2 => '\u{e01c}',
+            Keys::NumPad3 => '\u{e01d}',
+            Keys::NumPad4 => '\u{e01e}',
+            Keys::NumPad5 => '\u{e01f}',
+            Keys::NumPad6 => '\u{e020}',
+            Keys::NumPad7 => '\u{e021}',
+            Keys::NumPad8 => '\u{e022}',
+            Keys::NumPad9 => '\u{e023}',
+            Keys::Multiply => '\u{e024}',
+            Keys::Add => '\u{e025}',
+            Keys::Separator => '\u{e026}',
+            Keys::Subtract => '\u{e027}',
+            Keys::Decimal => '\u{e028}',
+            Keys::Divide => '\u{e029}',
+            Keys::F1 => '\u{e031}',
+            Keys::F2 => '\u{e032}',
+            Keys::F3 => '\u{e033}',
+            Keys::F4 => '\u{e034}',
+            Keys::F5 => '\u{e035}',
+            Keys::F6 => '\u{e036}',
+            Keys::F7 => '\u{e037}',
+            Keys::F8 => '\u{e038}',
+            Keys::F9 => '\u{e039}',
+            Keys::F10 => '\u{e03a}',
+            Keys::F11 => '\u{e03b}',
+            Keys::F12 => '\u{e03c}',
+            Keys::Meta => '\u{e03d}',
+            Keys::Command => '\u{e03d}',
+        }
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,10 +1,10 @@
 //! Key codes for use with Actions.
 
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
 
 /// Key codes for use with Actions.
 #[derive(Debug)]
-pub enum Keys {
+pub enum Key {
     /// Null
     Null,
     /// Cancel
@@ -119,76 +119,80 @@ pub enum Keys {
     Command,
 }
 
-impl From<Keys> for char {
-    fn from(k: Keys) -> char {
+impl From<Key> for char {
+    fn from(k: Key) -> char {
         match k {
-            Keys::Null => '\u{e000}',
-            Keys::Cancel => '\u{e001}',
-            Keys::Help => '\u{e002}',
-            Keys::Backspace => '\u{e003}',
-            Keys::Tab => '\u{e004}',
-            Keys::Clear => '\u{e005}',
-            Keys::Return => '\u{e006}',
-            Keys::Enter => '\u{e007}',
-            Keys::Shift => '\u{e008}',
-            Keys::Control => '\u{e009}',
-            Keys::Alt => '\u{e00a}',
-            Keys::Pause => '\u{e00b}',
-            Keys::Escape => '\u{e00c}',
-            Keys::Space => '\u{e00d}',
-            Keys::PageUp => '\u{e00e}',
-            Keys::PageDown => '\u{e00f}',
-            Keys::End => '\u{e010}',
-            Keys::Home => '\u{e011}',
-            Keys::Left => '\u{e012}',
-            Keys::Up => '\u{e013}',
-            Keys::Right => '\u{e014}',
-            Keys::Down => '\u{e015}',
-            Keys::Insert => '\u{e016}',
-            Keys::Delete => '\u{e017}',
-            Keys::Semicolon => '\u{e018}',
-            Keys::Equals => '\u{e019}',
-            Keys::NumPad0 => '\u{e01a}',
-            Keys::NumPad1 => '\u{e01b}',
-            Keys::NumPad2 => '\u{e01c}',
-            Keys::NumPad3 => '\u{e01d}',
-            Keys::NumPad4 => '\u{e01e}',
-            Keys::NumPad5 => '\u{e01f}',
-            Keys::NumPad6 => '\u{e020}',
-            Keys::NumPad7 => '\u{e021}',
-            Keys::NumPad8 => '\u{e022}',
-            Keys::NumPad9 => '\u{e023}',
-            Keys::Multiply => '\u{e024}',
-            Keys::Add => '\u{e025}',
-            Keys::Separator => '\u{e026}',
-            Keys::Subtract => '\u{e027}',
-            Keys::Decimal => '\u{e028}',
-            Keys::Divide => '\u{e029}',
-            Keys::F1 => '\u{e031}',
-            Keys::F2 => '\u{e032}',
-            Keys::F3 => '\u{e033}',
-            Keys::F4 => '\u{e034}',
-            Keys::F5 => '\u{e035}',
-            Keys::F6 => '\u{e036}',
-            Keys::F7 => '\u{e037}',
-            Keys::F8 => '\u{e038}',
-            Keys::F9 => '\u{e039}',
-            Keys::F10 => '\u{e03a}',
-            Keys::F11 => '\u{e03b}',
-            Keys::F12 => '\u{e03c}',
-            Keys::Meta => '\u{e03d}',
-            Keys::Command => '\u{e03d}',
+            Key::Null => '\u{e000}',
+            Key::Cancel => '\u{e001}',
+            Key::Help => '\u{e002}',
+            Key::Backspace => '\u{e003}',
+            Key::Tab => '\u{e004}',
+            Key::Clear => '\u{e005}',
+            Key::Return => '\u{e006}',
+            Key::Enter => '\u{e007}',
+            Key::Shift => '\u{e008}',
+            Key::Control => '\u{e009}',
+            Key::Alt => '\u{e00a}',
+            Key::Pause => '\u{e00b}',
+            Key::Escape => '\u{e00c}',
+            Key::Space => '\u{e00d}',
+            Key::PageUp => '\u{e00e}',
+            Key::PageDown => '\u{e00f}',
+            Key::End => '\u{e010}',
+            Key::Home => '\u{e011}',
+            Key::Left => '\u{e012}',
+            Key::Up => '\u{e013}',
+            Key::Right => '\u{e014}',
+            Key::Down => '\u{e015}',
+            Key::Insert => '\u{e016}',
+            Key::Delete => '\u{e017}',
+            Key::Semicolon => '\u{e018}',
+            Key::Equals => '\u{e019}',
+            Key::NumPad0 => '\u{e01a}',
+            Key::NumPad1 => '\u{e01b}',
+            Key::NumPad2 => '\u{e01c}',
+            Key::NumPad3 => '\u{e01d}',
+            Key::NumPad4 => '\u{e01e}',
+            Key::NumPad5 => '\u{e01f}',
+            Key::NumPad6 => '\u{e020}',
+            Key::NumPad7 => '\u{e021}',
+            Key::NumPad8 => '\u{e022}',
+            Key::NumPad9 => '\u{e023}',
+            Key::Multiply => '\u{e024}',
+            Key::Add => '\u{e025}',
+            Key::Separator => '\u{e026}',
+            Key::Subtract => '\u{e027}',
+            Key::Decimal => '\u{e028}',
+            Key::Divide => '\u{e029}',
+            Key::F1 => '\u{e031}',
+            Key::F2 => '\u{e032}',
+            Key::F3 => '\u{e033}',
+            Key::F4 => '\u{e034}',
+            Key::F5 => '\u{e035}',
+            Key::F6 => '\u{e036}',
+            Key::F7 => '\u{e037}',
+            Key::F8 => '\u{e038}',
+            Key::F9 => '\u{e039}',
+            Key::F10 => '\u{e03a}',
+            Key::F11 => '\u{e03b}',
+            Key::F12 => '\u{e03c}',
+            Key::Meta => '\u{e03d}',
+            Key::Command => '\u{e03d}',
         }
     }
 }
 
-impl<S> Add<S> for Keys
-where
-    S: AsRef<str>,
-{
+impl Add<Key> for String {
     type Output = String;
 
-    fn add(self, rhs: S) -> Self::Output {
-        char::from(self).to_string() + rhs.as_ref()
+    fn add(mut self, rhs: Key) -> Self::Output {
+        self.push(rhs.into());
+        self
+    }
+}
+
+impl AddAssign<Key> for String {
+    fn add_assign(&mut self, rhs: Key) {
+        self.push(rhs.into());
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -260,4 +260,12 @@ mod tests {
         k += Key::Control;
         assert_eq!(k, "test\u{e009}".to_string());
     }
+
+    #[test]
+    fn test_key_key_string() {
+        assert_eq!(
+            Key::Control + Key::Alt + "e",
+            "\u{e009}\u{e00a}e".to_string()
+        );
+    }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,5 +1,7 @@
 //! Key codes for use with Actions.
 
+use std::ops::Add;
+
 /// Key codes for use with Actions.
 #[derive(Debug)]
 pub enum Keys {
@@ -177,5 +179,16 @@ impl From<Keys> for char {
             Keys::Meta => '\u{e03d}',
             Keys::Command => '\u{e03d}',
         }
+    }
+}
+
+impl<S> Add<S> for Keys
+where
+    S: AsRef<str>,
+{
+    type Output = String;
+
+    fn add(self, rhs: S) -> Self::Output {
+        char::from(self).to_string() + rhs.as_ref()
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,9 +1,10 @@
 //! Key codes for use with Actions.
 
+use std::fmt::{Display, Formatter};
 use std::ops::{Add, AddAssign};
 
 /// Key codes for use with Actions.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Key {
     /// Null
     Null,
@@ -179,6 +180,12 @@ impl From<Key> for char {
             Key::Meta => '\u{e03d}',
             Key::Command => '\u{e03d}',
         }
+    }
+}
+
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", char::from(self.clone()))
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -196,3 +196,68 @@ impl AddAssign<Key> for String {
         self.push(rhs.into());
     }
 }
+
+impl Add<String> for Key {
+    type Output = String;
+
+    fn add(self, rhs: String) -> Self::Output {
+        format!("{}{}", char::from(self), rhs)
+    }
+}
+
+impl Add<Key> for Key {
+    type Output = String;
+
+    fn add(self, rhs: Key) -> Self::Output {
+        format!("{}{}", char::from(self), char::from(rhs))
+    }
+}
+
+impl Add<&str> for Key {
+    type Output = String;
+
+    fn add(self, rhs: &str) -> Self::Output {
+        format!("{}{}", char::from(self), rhs)
+    }
+}
+
+impl Add<Key> for &str {
+    type Output = String;
+
+    fn add(self, rhs: Key) -> Self::Output {
+        format!("{}{}", self, char::from(rhs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keys() {
+        assert_eq!(Key::Control + Key::Shift, "\u{e009}\u{e008}".to_string());
+    }
+
+    #[test]
+    fn test_key_str() {
+        assert_eq!(Key::Control + "a", "\u{e009}a".to_string());
+        assert_eq!("a" + Key::Control, "a\u{e009}".to_string());
+    }
+
+    #[test]
+    fn test_key_string() {
+        assert_eq!(Key::Control + "a".to_string(), "\u{e009}a".to_string());
+        assert_eq!("a".to_string() + Key::Control, "a\u{e009}".to_string());
+    }
+
+    #[test]
+    fn test_string_addassign() {
+        let mut k = String::new();
+        k += Key::Control;
+        assert_eq!(k, "\u{e009}".to_string());
+
+        let mut k = "test".to_string();
+        k += Key::Control;
+        assert_eq!(k, "test\u{e009}".to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ pub use client::Client;
 pub mod actions;
 pub mod cookies;
 pub mod elements;
-pub mod keys;
+pub mod key;
 
 pub mod wait;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,3 +263,9 @@ pub mod wait;
 pub mod wd;
 #[doc(inline)]
 pub use wd::Locator;
+
+/// Re-export bundled types;
+pub mod external {
+    pub use url::Url;
+    pub use webdriver;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
 //! let src = img.attr("src").await?.expect("image should have a src");
 //! // now build a raw HTTP client request (which also has all current cookies)
-//! let raw = img.client.raw_client_for(hyper::Method::GET, &src).await?;
+//! let raw = img.client().raw_client_for(hyper::Method::GET, &src).await?;
 //!
 //! // we then read out the image bytes
 //! use futures_util::TryStreamExt;
@@ -255,17 +255,13 @@ pub mod client;
 #[doc(inline)]
 pub use client::Client;
 
+pub mod actions;
 pub mod cookies;
 pub mod elements;
+pub mod keys;
 
 pub mod wait;
 
 pub mod wd;
 #[doc(inline)]
 pub use wd::Locator;
-
-/// Re-export bundled types;
-pub mod external {
-    pub use url::Url;
-    pub use webdriver;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
 //! let src = img.attr("src").await?.expect("image should have a src");
 //! // now build a raw HTTP client request (which also has all current cookies)
-//! let raw = img.client().raw_client_for(hyper::Method::GET, &src).await?;
+//! let raw = img.client.raw_client_for(hyper::Method::GET, &src).await?;
 //!
 //! // we then read out the image bytes
 //! use futures_util::TryStreamExt;

--- a/src/session.rs
+++ b/src/session.rs
@@ -873,6 +873,7 @@ where
                             "invalid session id" => ErrorStatus::InvalidSessionId,
                             "no such element" => ErrorStatus::NoSuchElement,
                             "no such window" => ErrorStatus::NoSuchWindow,
+                            "no such alert" => ErrorStatus::NoSuchAlert,
                             "stale element reference" => ErrorStatus::NoSuchElement,
                             _ => unreachable!(
                                 "received unknown error ({}) for NOT_FOUND status code",

--- a/src/session.rs
+++ b/src/session.rs
@@ -461,6 +461,10 @@ where
             return self.wdb.join("session");
         }
 
+        if let WebDriverCommand::Status = *cmd {
+            return self.wdb.join("status");
+        }
+
         let base = {
             self.wdb
                 .join(&format!("session/{}/", self.session.as_ref().unwrap()))?
@@ -549,7 +553,7 @@ where
                 base.join(&format!("element/{}/screenshot", we.0))
             }
             WebDriverCommand::Print(..) => base.join("print"),
-            WebDriverCommand::Status => base.join("status"),
+            WebDriverCommand::Status => unreachable!(),
             _ => unimplemented!(),
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,7 +48,7 @@ pub(crate) struct Task {
 }
 
 impl Client {
-    pub(crate) fn issue<C>(&mut self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
+    pub(crate) fn issue<C>(&self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
     where
         C: Into<Cmd>,
     {
@@ -369,7 +369,7 @@ where
         });
 
         // now that the session is running, let's do the handshake
-        let mut client = Client {
+        let client = Client {
             tx: tx.clone(),
             is_legacy: false,
         };

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,7 +48,7 @@ pub(crate) struct Task {
 }
 
 impl Client {
-    pub(crate) fn issue<C>(&self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
+    pub(crate) fn issue<C>(&mut self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
     where
         C: Into<Cmd>,
     {
@@ -369,7 +369,7 @@ where
         });
 
         // now that the session is running, let's do the handshake
-        let client = Client {
+        let mut client = Client {
             tx: tx.clone(),
             is_legacy: false,
         };

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -167,14 +167,19 @@ impl<'a> Locator<'a> {
 /// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebDriverStatus {
-    ready: bool,
-    message: String,
+    /// True if the webdriver is ready to start a new session.
+    ///
+    /// NOTE: Geckodriver will return `false` if a session has already started, since it
+    ///       only supports a single session.
+    pub ready: bool,
+    /// The current status message.
+    pub message: String,
 }
 
 /// Timeout configuration, for various timeout settings.
 ///
 /// Used by [`Client::get_timeouts()`] and [`Client::set_timeouts()`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TimeoutConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     script: Option<u64>,

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -178,7 +178,7 @@ pub struct WebDriverStatus {
 
 /// Timeout configuration, for various timeout settings.
 ///
-/// Used by [`Client::get_timeouts()`] and [`Client::set_timeouts()`].
+/// Used by [`Client::get_timeouts()`] and [`Client::update_timeouts()`].
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TimeoutConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -168,7 +168,7 @@ impl<'a> Locator<'a> {
 /// [`Client::status()`]: crate::Client::status
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebDriverStatus {
-    ready: String,
+    ready: bool,
     message: String,
 }
 

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -1,6 +1,7 @@
 //! WebDriver types and declarations.
 
 use crate::error;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
@@ -155,4 +156,15 @@ impl<'a> Locator<'a> {
             },
         }
     }
+}
+
+/// The WebDriver status as returned by [`Client::status()`].
+///
+/// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
+///
+/// [`Client::status()`]: crate::Client::status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebDriverStatus {
+    ready: String,
+    message: String,
 }

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -1,6 +1,8 @@
 //! WebDriver types and declarations.
 
 use crate::error;
+#[cfg(doc)]
+use crate::Client;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -13,7 +15,6 @@ use webdriver::command::TimeoutsParameters;
 /// Should be obtained it via [`Client::window()`] method (or similar).
 ///
 /// [1]: https://www.w3.org/TR/webdriver/#dfn-window-handles
-/// [`Client::window()`]: crate::Client::window
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WindowHandle(String);
 
@@ -164,8 +165,6 @@ impl<'a> Locator<'a> {
 /// The WebDriver status as returned by [`Client::status()`].
 ///
 /// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
-///
-/// [`Client::status()`]: crate::Client::status
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebDriverStatus {
     ready: bool,
@@ -175,9 +174,6 @@ pub struct WebDriverStatus {
 /// Timeout configuration, for various timeout settings.
 ///
 /// Used by [`Client::get_timeouts()`] and [`Client::set_timeouts()`].
-///
-/// [`Client::get_timeouts()`]: crate::Client::get_timeouts
-/// [`Client::set_timeouts()`]: crate::Client::set_timeouts
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeoutConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,8 +207,6 @@ impl TimeoutConfiguration {
     /// NOTE: It is recommended to leave the `implicit` timeout at 0 seconds, because that makes
     ///       it possible to check for the non-existence of an element without an implicit delay.
     ///       Also see [`Client::wait()`] for element polling functionality.
-    ///
-    /// [`Client::wait()`]: crate::Client::wait
     pub fn new(
         script: Option<Duration>,
         page_load: Option<Duration>,
@@ -256,22 +250,12 @@ impl TimeoutConfiguration {
     }
 }
 
-impl From<TimeoutsParameters> for TimeoutConfiguration {
-    fn from(tp: TimeoutsParameters) -> Self {
-        Self {
-            script: tp.script.flatten(),
-            page_load: tp.page_load,
-            implicit: tp.implicit,
-        }
-    }
-}
-
-impl From<TimeoutConfiguration> for TimeoutsParameters {
-    fn from(tc: TimeoutConfiguration) -> Self {
-        Self {
-            script: tc.script.map(Some),
-            page_load: tc.page_load,
-            implicit: tc.implicit,
+impl TimeoutConfiguration {
+    pub(crate) fn into_params(self) -> TimeoutsParameters {
+        TimeoutsParameters {
+            script: self.script.map(Some),
+            page_load: self.page_load,
+            implicit: self.implicit,
         }
     }
 }

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
+use std::time::Duration;
+use webdriver::command::TimeoutsParameters;
 
 /// A [handle][1] to a browser window.
 ///
@@ -167,4 +169,108 @@ impl<'a> Locator<'a> {
 pub struct WebDriverStatus {
     ready: String,
     message: String,
+}
+
+/// Timeout configuration, for various timeout settings.
+///
+/// Used by [`Client::get_timeouts()`] and [`Client::set_timeouts()`].
+///
+/// [`Client::get_timeouts()`]: crate::Client::get_timeouts
+/// [`Client::set_timeouts()`]: crate::Client::set_timeouts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeoutConfiguration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    script: Option<u64>,
+    #[serde(rename = "pageLoad", skip_serializing_if = "Option::is_none")]
+    page_load: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    implicit: Option<u64>,
+}
+
+impl Default for TimeoutConfiguration {
+    fn default() -> Self {
+        TimeoutConfiguration::new(
+            Some(Duration::from_secs(60)),
+            Some(Duration::from_secs(60)),
+            Some(Duration::from_secs(0)),
+        )
+    }
+}
+
+impl TimeoutConfiguration {
+    /// Create new timeout configuration.
+    ///
+    /// The various settings are as follows:
+    /// - script     Determines when to interrupt a script that is being evaluated.
+    ///              Default is 60 seconds.
+    /// - page_load  Provides the timeout limit used to interrupt navigation of the browsing
+    ///              context. Default is 60 seconds.
+    /// - implicit   Gives the timeout of when to abort locating an element. Default is 0 seconds.
+    ///
+    /// NOTE: It is recommended to leave the `implicit` timeout at 0 seconds, because that makes
+    ///       it possible to check for the non-existence of an element without an implicit delay.
+    ///       Also see [`Client::wait()`] for element polling functionality.
+    ///
+    /// [`Client::wait()`]: crate::Client::wait
+    pub fn new(
+        script: Option<Duration>,
+        page_load: Option<Duration>,
+        implicit: Option<Duration>,
+    ) -> Self {
+        TimeoutConfiguration {
+            script: script.map(|x| x.as_millis() as u64),
+            page_load: page_load.map(|x| x.as_millis() as u64),
+            implicit: implicit.map(|x| x.as_millis() as u64),
+        }
+    }
+
+    /// Get the script timeout.
+    pub fn script(&self) -> Option<Duration> {
+        self.script.map(Duration::from_millis)
+    }
+
+    /// Set the script timeout.
+    pub fn set_script(&mut self, timeout: Option<Duration>) {
+        self.script = timeout.map(|x| x.as_millis() as u64);
+    }
+
+    /// Get the page load timeout.
+    pub fn page_load(&self) -> Option<Duration> {
+        self.page_load.map(Duration::from_millis)
+    }
+
+    /// Set the page load timeout.
+    pub fn set_page_load(&mut self, timeout: Option<Duration>) {
+        self.page_load = timeout.map(|x| x.as_millis() as u64);
+    }
+
+    /// Get the implicit wait timeout.
+    pub fn implicit(&self) -> Option<Duration> {
+        self.implicit.map(Duration::from_millis)
+    }
+
+    /// Set the implicit wait timeout.
+    pub fn set_implicit(&mut self, timeout: Option<Duration>) {
+        self.implicit = timeout.map(|x| x.as_millis() as u64);
+    }
+}
+
+impl From<TimeoutsParameters> for TimeoutConfiguration {
+    fn from(tp: TimeoutsParameters) -> Self {
+        Self {
+            script: tp.script.flatten(),
+            page_load: tp.page_load,
+            implicit: tp.implicit,
+        }
+    }
+}
+
+impl From<TimeoutConfiguration> for TimeoutsParameters {
+    fn from(tc: TimeoutConfiguration) -> Self {
+        Self {
+            script: tc.script.map(Some),
+            page_load: tc.page_load,
+            implicit: tc.implicit,
+        }
+    }
 }

--- a/src/wd.rs
+++ b/src/wd.rs
@@ -13,6 +13,7 @@ use webdriver::command::TimeoutsParameters;
 /// Should be obtained it via [`Client::window()`] method (or similar).
 ///
 /// [1]: https://www.w3.org/TR/webdriver/#dfn-window-handles
+/// [`Client::window()`]: crate::Client::window
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WindowHandle(String);
 

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -1,6 +1,5 @@
 //! Alert tests
-#[macro_use]
-extern crate serial_test;
+use serial_test::serial;
 
 use crate::common::sample_page_url;
 use fantoccini::actions::{

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -1,6 +1,4 @@
-//! Alert tests
-use serial_test::serial;
-
+//! Actions tests
 use crate::common::sample_page_url;
 use fantoccini::actions::{
     Actions, InputSource, KeyAction, KeyActions, MouseActions, NullActions, PointerAction,
@@ -8,6 +6,7 @@ use fantoccini::actions::{
 };
 use fantoccini::key::Key;
 use fantoccini::{error, Client, Locator};
+use serial_test::serial;
 use std::time::Duration;
 use time::Instant;
 

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -85,6 +85,9 @@ async fn actions_mouse(mut c: Client, port: u16) -> Result<(), error::CmdError> 
 }
 
 async fn actions_mouse_move(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    // Set window size to avoid moving the cursor out-of-bounds during actions.
+    c.set_window_rect(0, 0, 800, 800).await?;
+
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -1,0 +1,235 @@
+//! Alert tests
+#[macro_use]
+extern crate serial_test;
+extern crate fantoccini;
+extern crate futures_util;
+
+use crate::common::sample_page_url;
+use fantoccini::actions::{
+    Actions, InputSource, KeyAction, KeyActions, MouseActions, NullActions, PointerAction,
+    MOUSE_BUTTON_LEFT,
+};
+use fantoccini::keys::Key;
+use fantoccini::{error, Client, Locator};
+use std::time::Duration;
+use time::Instant;
+
+mod common;
+
+async fn actions_null(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let null_actions = NullActions::new("null".to_string()).pause(Duration::from_secs(1));
+    let now = Instant::now();
+    c.perform_actions(vec![null_actions].into()).await?;
+    assert!(now.elapsed().as_seconds_f64() >= 1.0);
+    Ok(())
+}
+
+async fn actions_key(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+
+    // Test pause.
+    let key_pause = KeyActions::new("key".to_string()).pause(Duration::from_secs(1));
+    let now = Instant::now();
+    c.perform_actions(vec![key_pause].into()).await?;
+    assert!(now.elapsed().as_seconds_f64() >= 1.0);
+
+    // Test key down/up.
+    let mut elem = c.find(Locator::Id("text-input")).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "");
+
+    let key_actions = KeyActions::new("key".to_string())
+        .then(KeyAction::Down { value: 'a' })
+        .then(KeyAction::Up { value: 'a' });
+    elem.click().await?;
+    c.perform_actions(vec![key_actions].into()).await?;
+    let mut elem = c.find(Locator::Id("text-input")).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "a");
+    Ok(())
+}
+
+async fn actions_mouse(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+
+    // Test pause.
+    let mouse_pause = MouseActions::new("mouse".to_string()).pause(Duration::from_secs(1));
+    let now = Instant::now();
+    c.perform_actions(vec![mouse_pause].into()).await?;
+    assert!(now.elapsed().as_seconds_f64() >= 1.0);
+
+    let elem = c.find(Locator::Id("button-alert")).await?;
+
+    // Test mouse down/up.
+    let mouse_actions = MouseActions::new("mouse".to_string())
+        .then(PointerAction::MoveToElement {
+            element: elem,
+            duration: None,
+            x: 0,
+            y: 0,
+        })
+        .then(PointerAction::Down {
+            button: MOUSE_BUTTON_LEFT,
+        })
+        .then(PointerAction::Up {
+            button: MOUSE_BUTTON_LEFT,
+        });
+
+    c.perform_actions(vec![mouse_actions].into()).await?;
+    assert_eq!(c.get_alert_text().await?, "This is an alert");
+    c.dismiss_alert().await?;
+    Ok(())
+}
+
+async fn actions_mouse_move(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+
+    let mut elem = c.find(Locator::Id("text-input")).await?;
+    let rect = elem.rectangle().await?;
+    let elem_center_y = rect.1 + (rect.3 / 2.0);
+
+    elem.send_keys("fantoccini").await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "fantoccini");
+
+    // Test mouse MoveTo and MoveBy, by implementing drag-and-drop to select text
+    // in the text input element.
+    let mouse_actions = MouseActions::new("mouse".to_string())
+        // Move to the left edge of the input element.
+        // Offset by 1 pixel to ensure we click inside the element.
+        .then(PointerAction::MoveTo {
+            duration: None,
+            x: (rect.0 as i64) + 1,
+            y: elem_center_y as i64,
+        })
+        // Press left mouse button down.
+        .then(PointerAction::Down {
+            button: MOUSE_BUTTON_LEFT,
+        })
+        // Drag mouse to the right edge of the input element.
+        // Reduce width by 2 pixels to ensure we stop dragging just inside the right edge.
+        .then(PointerAction::MoveBy {
+            duration: None,
+            x: (rect.2 as i64) - 2,
+            y: 0,
+        })
+        // Release left mouse button.
+        .then(PointerAction::Up {
+            button: MOUSE_BUTTON_LEFT,
+        });
+
+    // Press the delete key after the mouse actions. Note that we need to pause
+    // once for each mouse action, so that the Key down action occurs afterwards.
+    let key_actions = KeyActions::new("key".to_string())
+        .pause(Duration::default())
+        .pause(Duration::default())
+        .pause(Duration::default())
+        .pause(Duration::default())
+        .then(KeyAction::Down {
+            value: Key::Delete.into(),
+        });
+
+    let actions = Actions::from(mouse_actions).and(key_actions);
+    c.perform_actions(actions).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "");
+    Ok(())
+}
+
+async fn actions_release(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+
+    // Focus the input element.
+    let elem = c.find(Locator::Id("text-input")).await?;
+    elem.click().await?;
+
+    // Add initial text.
+    let mut elem = c.find(Locator::Id("text-input")).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "");
+
+    // Press CONTROL key down and hold it.
+    let key_actions = KeyActions::new("key".to_string()).then(KeyAction::Down {
+        value: Key::Control.into(),
+    });
+    c.perform_actions(vec![key_actions].into()).await?;
+
+    // Now release all actions. This should release the control key.
+    c.release_actions().await?;
+
+    // Now press the 'a' key again.
+    //
+    // If the Control key was not released, this would do `Ctrl+a` (i.e. select all)
+    // but there is no text so it would do nothing.
+    //
+    // However if the Control key was released (as expected)
+    // then this will type 'a' into the text element.
+    let key_actions = KeyActions::new("key".to_string()).then(KeyAction::Down { value: 'a' });
+    c.perform_actions(vec![key_actions].into()).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "a");
+    Ok(())
+}
+
+mod firefox {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn actions_null_test() {
+        local_tester!(actions_null, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn actions_key_test() {
+        local_tester!(actions_key, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn actions_mouse_test() {
+        local_tester!(actions_mouse, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn actions_mouse_move_test() {
+        local_tester!(actions_mouse_move, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn actions_release_test() {
+        local_tester!(actions_release, "firefox");
+    }
+}
+
+mod chrome {
+    use super::*;
+
+    #[test]
+    fn actions_null_test() {
+        local_tester!(actions_null, "chrome");
+    }
+
+    #[test]
+    fn actions_key_test() {
+        local_tester!(actions_key, "chrome");
+    }
+
+    #[test]
+    fn actions_mouse_test() {
+        local_tester!(actions_mouse, "chrome");
+    }
+
+    #[test]
+    fn actions_mouse_move_test() {
+        local_tester!(actions_mouse_move, "chrome");
+    }
+
+    #[test]
+    fn actions_release_test() {
+        local_tester!(actions_release, "chrome");
+    }
+}

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -1,0 +1,122 @@
+//! Alert tests
+#[macro_use]
+extern crate serial_test;
+extern crate fantoccini;
+extern crate futures_util;
+
+use crate::common::sample_page_url;
+use fantoccini::{error, Client, Locator};
+
+mod common;
+
+async fn alert_accept(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    c.find(Locator::Id("button-alert")).await?.click().await?;
+    assert_eq!(c.get_alert_text().await?, "This is an alert");
+    c.accept_alert().await?;
+    assert!(matches!(
+        c.get_alert_text().await,
+        Err(error::CmdError::NoSuchAlert(..))
+    ));
+
+    c.find(Locator::Id("button-confirm")).await?.click().await?;
+    assert_eq!(c.get_alert_text().await?, "Press OK or Cancel");
+    c.accept_alert().await?;
+    assert!(matches!(
+        c.get_alert_text().await,
+        Err(error::CmdError::NoSuchAlert(..))
+    ));
+    assert_eq!(
+        c.find(Locator::Id("alert-answer")).await?.text().await?,
+        "OK"
+    );
+
+    Ok(())
+}
+
+async fn alert_dismiss(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    c.find(Locator::Id("button-alert")).await?.click().await?;
+    assert_eq!(c.get_alert_text().await?, "This is an alert");
+    c.dismiss_alert().await?;
+    assert!(matches!(
+        c.get_alert_text().await,
+        Err(error::CmdError::NoSuchAlert(..))
+    ));
+
+    c.find(Locator::Id("button-confirm")).await?.click().await?;
+    assert_eq!(c.get_alert_text().await?, "Press OK or Cancel");
+    c.dismiss_alert().await?;
+    assert!(matches!(
+        c.get_alert_text().await,
+        Err(error::CmdError::NoSuchAlert(..))
+    ));
+    assert_eq!(
+        c.find(Locator::Id("alert-answer")).await?.text().await?,
+        "Cancel"
+    );
+
+    Ok(())
+}
+
+async fn alert_text(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    c.find(Locator::Id("button-prompt")).await?.click().await?;
+    assert_eq!(c.get_alert_text().await?, "What is your name?");
+    c.send_alert_text("Fantoccini").await?;
+    c.accept_alert().await?;
+    assert!(matches!(
+        c.get_alert_text().await,
+        Err(error::CmdError::NoSuchAlert(..))
+    ));
+    assert_eq!(
+        c.find(Locator::Id("alert-answer")).await?.text().await?,
+        "Fantoccini"
+    );
+
+    Ok(())
+}
+
+mod firefox {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn alert_accept_test() {
+        local_tester!(alert_accept, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn alert_dismiss_test() {
+        local_tester!(alert_dismiss, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn alert_text_test() {
+        local_tester!(alert_text, "firefox");
+    }
+}
+
+mod chrome {
+    use super::*;
+
+    #[test]
+    fn alert_accept_test() {
+        local_tester!(alert_accept, "chrome");
+    }
+
+    #[test]
+    fn alert_dismiss_test() {
+        local_tester!(alert_dismiss, "chrome");
+    }
+
+    #[test]
+    fn alert_text_test() {
+        local_tester!(alert_text, "chrome");
+    }
+}

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -1,6 +1,5 @@
 //! Alert tests
-#[macro_use]
-extern crate serial_test;
+use serial_test::serial;
 extern crate fantoccini;
 extern crate futures_util;
 

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -1,10 +1,7 @@
 //! Alert tests
-use serial_test::serial;
-extern crate fantoccini;
-extern crate futures_util;
-
 use crate::common::sample_page_url;
 use fantoccini::{error, Client, Locator};
+use serial_test::serial;
 
 mod common;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -231,3 +231,11 @@ fn file_not_found() -> Response<Body> {
         .body(Body::empty())
         .unwrap()
 }
+
+pub fn sample_page_url(port: u16) -> String {
+    format!("http://localhost:{}/sample_page.html", port)
+}
+
+pub fn other_page_url(port: u16) -> String {
+    format!("http://localhost:{}/other_page.html", port)
+}

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -5,7 +5,7 @@ extern crate fantoccini;
 extern crate futures_util;
 
 use crate::common::sample_page_url;
-use fantoccini::keys::Key;
+use fantoccini::key::Key;
 use fantoccini::{error, Client, Locator};
 
 mod common;
@@ -68,7 +68,7 @@ async fn element_tag_name(mut c: Client, port: u16) -> Result<(), error::CmdErro
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
-    assert_eq!(elem.tag_name().await?, "input");
+    assert_eq!(elem.tag_name().await?.to_lowercase(), "input");
     Ok(())
 }
 

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -1,6 +1,5 @@
 //! Element tests
-#[macro_use]
-extern crate serial_test;
+use serial_test::serial;
 extern crate fantoccini;
 extern crate futures_util;
 
@@ -68,7 +67,7 @@ async fn element_tag_name(mut c: Client, port: u16) -> Result<(), error::CmdErro
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
-    assert_eq!(elem.tag_name().await?.to_lowercase(), "input");
+    assert!(elem.tag_name().await?.eq_ignore_ascii_case("input"));
     Ok(())
 }
 

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -1,0 +1,193 @@
+//! Element tests
+#[macro_use]
+extern crate serial_test;
+extern crate fantoccini;
+extern crate futures_util;
+
+use crate::common::sample_page_url;
+use fantoccini::keys::Key;
+use fantoccini::{error, Client, Locator};
+
+mod common;
+
+async fn element_is(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    assert!(elem.is_enabled().await?);
+    assert!(elem.is_displayed().await?);
+    assert!(!elem.is_selected().await?);
+    elem.click().await?;
+    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    assert!(elem.is_selected().await?);
+
+    assert!(
+        !c.find(Locator::Id("checkbox-disabled"))
+            .await?
+            .is_enabled()
+            .await?
+    );
+    assert!(
+        !c.find(Locator::Id("checkbox-hidden"))
+            .await?
+            .is_displayed()
+            .await?
+    );
+    Ok(())
+}
+
+async fn element_attr(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    assert_eq!(elem.attr("id").await?.unwrap(), "checkbox-option-1");
+    assert!(elem.attr("invalid-attribute").await?.is_none());
+    Ok(())
+}
+
+async fn element_prop(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    assert_eq!(elem.prop("id").await?.unwrap(), "checkbox-option-1");
+    assert_eq!(elem.prop("checked").await?.unwrap(), "false");
+    assert!(elem.attr("invalid-property").await?.is_none());
+    Ok(())
+}
+
+async fn element_css_value(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("checkbox-hidden")).await?;
+    assert_eq!(elem.css_value("display").await?, "none");
+    assert_eq!(elem.css_value("invalid-css-value").await?, "");
+    Ok(())
+}
+
+async fn element_tag_name(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    assert_eq!(elem.tag_name().await?, "input");
+    Ok(())
+}
+
+async fn element_rect(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("button-alert")).await?;
+    let rect = elem.rectangle().await?;
+    // Rather than try to verify the exact position and size of the element,
+    // let's just verify that the returned values deserialized ok and
+    // are within the expected range.
+    assert!(rect.0 > 0.0);
+    assert!(rect.0 < 100.0);
+    assert!(rect.1 > 0.0);
+    assert!(rect.1 < 1000.0);
+    assert!(rect.2 > 0.0);
+    assert!(rect.2 < 200.0);
+    assert!(rect.3 > 0.0);
+    assert!(rect.3 < 200.0);
+    Ok(())
+}
+
+async fn element_send_keys(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    let mut elem = c.find(Locator::Id("text-input")).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "");
+    elem.send_keys("fantoccini").await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "fantoccini");
+    let ctrl_a = Key::Control + "a";
+    let backspace = Key::Backspace.to_string();
+    elem.send_keys(&ctrl_a).await?;
+    elem.send_keys(&backspace).await?;
+    assert_eq!(elem.prop("value").await?.unwrap(), "");
+
+    Ok(())
+}
+
+mod firefox {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn element_is_test() {
+        local_tester!(element_is, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_attr_test() {
+        local_tester!(element_attr, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_prop_test() {
+        local_tester!(element_prop, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_css_value_test() {
+        local_tester!(element_css_value, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_tag_name_test() {
+        local_tester!(element_tag_name, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_rect_test() {
+        local_tester!(element_rect, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn element_send_keys_test() {
+        local_tester!(element_send_keys, "firefox");
+    }
+}
+
+mod chrome {
+    use super::*;
+
+    #[test]
+    fn element_is_test() {
+        local_tester!(element_is, "chrome");
+    }
+
+    #[test]
+    fn element_attr_test() {
+        local_tester!(element_attr, "chrome");
+    }
+
+    #[test]
+    fn element_prop_test() {
+        local_tester!(element_prop, "chrome");
+    }
+
+    #[test]
+    fn element_css_value_test() {
+        local_tester!(element_css_value, "chrome");
+    }
+
+    #[test]
+    fn element_tag_name_test() {
+        local_tester!(element_tag_name, "chrome");
+    }
+
+    #[test]
+    fn element_rect_test() {
+        local_tester!(element_rect, "chrome");
+    }
+
+    #[test]
+    fn element_send_keys_test() {
+        local_tester!(element_send_keys, "chrome");
+    }
+}

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -1,11 +1,8 @@
 //! Element tests
-use serial_test::serial;
-extern crate fantoccini;
-extern crate futures_util;
-
 use crate::common::sample_page_url;
 use fantoccini::key::Key;
 use fantoccini::{error, Client, Locator};
+use serial_test::serial;
 
 mod common;
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,6 +1,5 @@
 //! Tests that don't make use of external websites.
-#[macro_use]
-extern crate serial_test;
+use serial_test::serial;
 extern crate fantoccini;
 extern crate futures_util;
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,11 +1,8 @@
 //! Tests that don't make use of external websites.
-use serial_test::serial;
-extern crate fantoccini;
-extern crate futures_util;
-
 use crate::common::{other_page_url, sample_page_url};
 use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{error, Client, Locator};
+use serial_test::serial;
 use std::time::Duration;
 
 mod common;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4,13 +4,12 @@ extern crate serial_test;
 extern crate fantoccini;
 extern crate futures_util;
 
+use crate::common::{other_page_url, sample_page_url};
+use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{error, Client, Locator};
+use std::time::Duration;
 
 mod common;
-
-fn sample_page_url(port: u16) -> String {
-    format!("http://localhost:{}/sample_page.html", port)
-}
 
 async fn goto(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
@@ -29,7 +28,7 @@ async fn find_and_click_link(mut c: Client, port: u16) -> Result<(), error::CmdE
         .await?;
 
     let new_url = c.current_url().await?;
-    let expected_url = format!("http://localhost:{}/other_page.html", port);
+    let expected_url = other_page_url(port);
     assert_eq!(new_url.as_str(), expected_url.as_str());
 
     c.close().await
@@ -353,6 +352,74 @@ async fn resolve_execute_async_value(mut c: Client, port: u16) -> Result<(), err
     Ok(())
 }
 
+async fn back_and_forward(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+
+    assert_eq!(c.current_url().await?.as_str(), sample_url);
+
+    let other_url = other_page_url(port);
+    c.goto(&other_url).await?;
+    assert_eq!(c.current_url().await?.as_str(), other_url);
+
+    c.back().await?;
+    assert_eq!(c.current_url().await?.as_str(), sample_url);
+
+    c.forward().await?;
+    assert_eq!(c.current_url().await?.as_str(), other_url);
+
+    Ok(())
+}
+
+async fn status_firefox(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+    // Geckodriver only supports a single session, and since we're already in a
+    // session, it should return `false` here.
+    assert!(!c.status().await?.ready);
+    Ok(())
+}
+
+async fn status_chrome(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+    // Chromedriver supports multiple sessions, so it should always return
+    // `true` here.
+    assert!(c.status().await?.ready);
+    Ok(())
+}
+
+async fn page_title(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+    let sample_url = sample_page_url(port);
+    c.goto(&sample_url).await?;
+    assert_eq!(c.title().await?, "Sample Page");
+    Ok(())
+}
+
+async fn timeouts(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+    let new_timeouts = TimeoutConfiguration::new(
+        Some(Duration::from_secs(60)),
+        Some(Duration::from_secs(60)),
+        Some(Duration::from_secs(30)),
+    );
+    c.set_timeouts(new_timeouts.clone()).await?;
+
+    let got_timeouts = c.get_timeouts().await?;
+    assert_eq!(got_timeouts, new_timeouts);
+
+    // Ensure partial update also works.
+    let update_timeouts = TimeoutConfiguration::new(None, None, Some(Duration::from_secs(0)));
+    c.set_timeouts(update_timeouts.clone()).await?;
+
+    let got_timeouts = c.get_timeouts().await?;
+    assert_eq!(
+        got_timeouts,
+        TimeoutConfiguration::new(
+            new_timeouts.script(),
+            new_timeouts.page_load(),
+            update_timeouts.implicit()
+        )
+    );
+
+    Ok(())
+}
+
 mod firefox {
     use super::*;
     #[test]
@@ -450,6 +517,30 @@ mod firefox {
     fn resolve_execute_async_value_test() {
         local_tester!(resolve_execute_async_value, "firefox");
     }
+
+    #[test]
+    #[serial]
+    fn back_and_forward_test() {
+        local_tester!(back_and_forward, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn status_test() {
+        local_tester!(status_firefox, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn title_test() {
+        local_tester!(page_title, "firefox");
+    }
+
+    #[test]
+    #[serial]
+    fn timeouts_test() {
+        local_tester!(timeouts, "firefox");
+    }
 }
 
 mod chrome {
@@ -523,5 +614,25 @@ mod chrome {
     #[test]
     fn select_by_test() {
         local_tester!(select_by, "chrome")
+    }
+
+    #[test]
+    fn back_and_forward_test() {
+        local_tester!(back_and_forward, "chrome");
+    }
+
+    #[test]
+    fn status_test() {
+        local_tester!(status_chrome, "chrome");
+    }
+
+    #[test]
+    fn title_test() {
+        local_tester!(page_title, "chrome");
+    }
+
+    #[test]
+    fn timeouts_test() {
+        local_tester!(timeouts, "chrome");
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -398,14 +398,14 @@ async fn timeouts(mut c: Client, _: u16) -> Result<(), error::CmdError> {
         Some(Duration::from_secs(60)),
         Some(Duration::from_secs(30)),
     );
-    c.set_timeouts(new_timeouts.clone()).await?;
+    c.update_timeouts(new_timeouts.clone()).await?;
 
     let got_timeouts = c.get_timeouts().await?;
     assert_eq!(got_timeouts, new_timeouts);
 
     // Ensure partial update also works.
     let update_timeouts = TimeoutConfiguration::new(None, None, Some(Duration::from_secs(0)));
-    c.set_timeouts(update_timeouts.clone()).await?;
+    c.update_timeouts(update_timeouts.clone()).await?;
 
     let got_timeouts = c.get_timeouts().await?;
     assert_eq!(

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -102,11 +102,7 @@ async fn raw_inner(mut c: Client) -> Result<(), error::CmdError> {
     let src = img.attr("src").await?.expect("image should have a src");
 
     // now build a raw HTTP client request (which also has all current cookies)
-    let raw = img
-        .client()
-        .clone()
-        .raw_client_for(Method::GET, &src)
-        .await?;
+    let raw = img.client().raw_client_for(Method::GET, &src).await?;
 
     // we then read out the image bytes
     let pixels = hyper::body::to_bytes(raw.into_body())

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -89,7 +89,7 @@ async fn send_keys_and_clear_input_inner(mut c: Client) -> Result<(), error::Cmd
         ""
     );
 
-    let mut c = e.client;
+    let mut c = e.client();
     c.close().await
 }
 
@@ -102,7 +102,11 @@ async fn raw_inner(mut c: Client) -> Result<(), error::CmdError> {
     let src = img.attr("src").await?.expect("image should have a src");
 
     // now build a raw HTTP client request (which also has all current cookies)
-    let raw = img.client.raw_client_for(Method::GET, &src).await?;
+    let raw = img
+        .client()
+        .clone()
+        .raw_client_for(Method::GET, &src)
+        .await?;
 
     // we then read out the image bytes
     let pixels = hyper::body::to_bytes(raw.into_body())

--- a/tests/test_html/sample_page.html
+++ b/tests/test_html/sample_page.html
@@ -88,5 +88,50 @@
             <option id="select3-option-3">Select3-Option3</option>
         </select>
     </div>
+    <div>
+        <script>
+            function showAlert() {
+                alert("This is an alert");
+            }
+
+            function showConfirm() {
+                const elem = document.getElementById("alert-answer");
+                if (confirm("Press OK or Cancel")) {
+                    elem.innerHTML = "OK";
+                } else {
+                    elem.innerHTML = "Cancel";
+                }
+            }
+
+            function showPrompt() {
+                document.getElementById("alert-answer").innerHTML = prompt("What is your name?");
+            }
+        </script>
+        <br /><br />
+        <button id="button-alert" onclick="showAlert()">Show alert</button>
+        <button id="button-confirm" onclick="showConfirm()">Show confirm</button>
+        <button id="button-prompt" onclick="showPrompt()">Show prompt</button>
+        <div id="alert-answer"></div>
+    </div>
+    <div>
+        <label>
+            <input type="checkbox" id="checkbox-option-1" />
+            Option 1
+        </label>
+
+        <label>
+            <input type="checkbox" id="checkbox-disabled" disabled />
+            Option 2
+        </label>
+
+        <label>
+            <input type="checkbox" id="checkbox-hidden" style="display: none;" />
+            Option 3
+        </label>
+    </div>
+    <div>
+        <label for="text-input">Text:</label>
+        <input type="text" id="text-input" />
+    </div>
 </body>
 </html>

--- a/tests/test_html/sample_page.html
+++ b/tests/test_html/sample_page.html
@@ -131,7 +131,7 @@
     </div>
     <div>
         <label for="text-input">Text:</label>
-        <input type="text" id="text-input" />
+        <input type="text" id="text-input" style="width: 200px; font-size:14px;"/>
     </div>
 </body>
 </html>


### PR DESCRIPTION
I've wired up and implemented most of the remaining `WebDriverCommand`s.

Some points of discussion:
1. A lot of methods in `fantoccini` take `&mut self` when mutable access is not required. In fact most methods should be fine with `&self`. Is this intentional?
2. In order to wrap `Element` in `thirtyfour`, I needed to make its members public. Is this going to cause any issues?
3. It would be nice to re-export some of the types used by `fantoccini`, so that calling crates can import (use) the exact versions without having to try to keep things in lockstep. I've add a couple of re-exports under `fantoccini::external` but feel free to suggest a better namespace. I'd also be fine with these being behind a feature flag in order to not pollute the namespace.
4. I haven't yet added tests (except for `add_cookie()`). I assume the desired approach is to continue with what is in tests/local.rs?