### PR TITLE
Make access to self immutable where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use fantoccini::{Client, Locator};
 // let's set up the sequence of steps we want the browser to take
 #[tokio::main]
 async fn main() -> Result<(), fantoccini::error::CmdError> {
-    let mut c = Client::new("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    let c = Client::new("http://localhost:4444").await.expect("failed to connect to WebDriver");
 
     // first, go to the Wikipedia page for Foobar
     c.goto("https://en.wikipedia.org/wiki/Foobar").await?;
@@ -61,7 +61,7 @@ Let's make the program do that for us instead:
 // go to the Wikipedia frontpage this time
 c.goto("https://www.wikipedia.org/").await?;
 // find the search form, fill it out, and submit it
-let mut f = c.form(Locator::Css("#search-form")).await?;
+let f = c.form(Locator::Css("#search-form")).await?;
 f.set_by_name("search", "foobar").await?
  .submit().await?;
 
@@ -79,7 +79,7 @@ What if we want to download a raw file? Fantoccini has you covered:
 // go back to the frontpage
 c.goto("https://www.wikipedia.org/").await?;
 // find the source for the Wikipedia globe
-let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
+let img = c.find(Locator::Css("img.central-featured-logo")).await?;
 let src = img.attr("src").await?.expect("image should have a src");
 // now build a raw HTTP client request (which also has all current cookies)
 let raw = img.client().raw_client_for(fantoccini::Method::GET, &src).await?;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -29,7 +29,7 @@ use tokio::time::sleep;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Connect to webdriver instance that is listening on port 4444
-    let mut client = ClientBuilder::native()
+    let client = ClientBuilder::native()
         .connect("http://localhost:4444")
         .await?;
 
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     button.click().await?;
 
     // Find the big textarea.
-    let mut code_area = client
+    let code_area = client
         .wait()
         .for_element(Locator::Css(".ace_text-input"))
         .await?;

--- a/examples/wait.rs
+++ b/examples/wait.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Connect to webdriver instance that is listening on port 4444
-    let mut client = ClientBuilder::native()
+    let client = ClientBuilder::native()
         .connect("http://localhost:4444")
         .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -91,7 +91,7 @@ impl Client {
     }
 
     /// Get the unique session ID assigned by the WebDriver server to this client.
-    pub async fn session_id(&mut self) -> Result<Option<String>, error::CmdError> {
+    pub async fn session_id(&self) -> Result<Option<String>, error::CmdError> {
         match self.issue(Cmd::GetSessionId).await? {
             Json::String(s) => Ok(Some(s)),
             Json::Null => Ok(None),
@@ -100,13 +100,13 @@ impl Client {
     }
 
     /// Set the User Agent string to use for all subsequent requests.
-    pub async fn set_ua<S: Into<String>>(&mut self, ua: S) -> Result<(), error::CmdError> {
+    pub async fn set_ua<S: Into<String>>(&self, ua: S) -> Result<(), error::CmdError> {
         self.issue(Cmd::SetUa(ua.into())).await?;
         Ok(())
     }
 
     /// Get the current User Agent string.
-    pub async fn get_ua(&mut self) -> Result<Option<String>, error::CmdError> {
+    pub async fn get_ua(&self) -> Result<Option<String>, error::CmdError> {
         match self.issue(Cmd::GetUa).await? {
             Json::String(s) => Ok(Some(s)),
             Json::Null => Ok(None),
@@ -126,7 +126,7 @@ impl Client {
     ///
     /// This function may be useful in conjunction with `raw_client_for`, as it allows you to close
     /// the automated browser window while doing e.g., a large download.
-    pub async fn close(&mut self) -> Result<(), error::CmdError> {
+    pub async fn close(&self) -> Result<(), error::CmdError> {
         self.issue(Cmd::Shutdown).await?;
         Ok(())
     }
@@ -141,7 +141,7 @@ impl Client {
     /// Note that an explicit call to [`Client::close`] will still terminate the session.
     ///
     /// This function is safe to call multiple times.
-    pub async fn persist(&mut self) -> Result<(), error::CmdError> {
+    pub async fn persist(&self) -> Result<(), error::CmdError> {
         self.issue(Cmd::Persist).await?;
         Ok(())
     }
@@ -155,7 +155,7 @@ impl Client {
     ///
     /// See [8.3 Status](https://www.w3.org/TR/webdriver1/#status) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Status"))]
-    pub async fn status(&mut self) -> Result<WebDriverStatus, error::CmdError> {
+    pub async fn status(&self) -> Result<WebDriverStatus, error::CmdError> {
         let res = self.issue(WebDriverCommand::Status).await?;
         let status: WebDriverStatus = serde_json::from_value(res)?;
         Ok(status)
@@ -166,7 +166,7 @@ impl Client {
     /// See [8.4 Get Timeouts](https://www.w3.org/TR/webdriver1/#get-timeouts) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Get Timeouts"))]
-    pub async fn get_timeouts(&mut self) -> Result<TimeoutConfiguration, error::CmdError> {
+    pub async fn get_timeouts(&self) -> Result<TimeoutConfiguration, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetTimeouts).await?;
         let timeouts: TimeoutConfiguration = serde_json::from_value(res)?;
         Ok(timeouts)
@@ -179,7 +179,7 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Set Timeouts"))]
     #[cfg_attr(docsrs, doc(alias = "Update Timeouts"))]
     pub async fn update_timeouts(
-        &mut self,
+        &self,
         timeouts: TimeoutConfiguration,
     ) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::SetTimeouts(timeouts.into_params()))
@@ -195,7 +195,7 @@ impl Client {
     /// See [9.1 Navigate To](https://www.w3.org/TR/webdriver1/#dfn-navigate-to) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Navigate To"))]
-    pub async fn goto(&mut self, url: &str) -> Result<(), error::CmdError> {
+    pub async fn goto(&self, url: &str) -> Result<(), error::CmdError> {
         let url = url.to_owned();
         let base = self.current_url_().await?;
         let url = base.join(&url)?;
@@ -211,11 +211,11 @@ impl Client {
     /// See [9.2 Get Current URL](https://www.w3.org/TR/webdriver1/#dfn-get-current-url) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Current URL"))]
-    pub async fn current_url(&mut self) -> Result<url::Url, error::CmdError> {
+    pub async fn current_url(&self) -> Result<url::Url, error::CmdError> {
         self.current_url_().await
     }
 
-    pub(crate) async fn current_url_(&mut self) -> Result<url::Url, error::CmdError> {
+    pub(crate) async fn current_url_(&self) -> Result<url::Url, error::CmdError> {
         let url = self.issue(WebDriverCommand::GetCurrentUrl).await?;
         if let Some(url) = url.as_str() {
             let url = if url.is_empty() { "about:blank" } else { url };
@@ -229,7 +229,7 @@ impl Client {
     ///
     /// See [9.3 Back](https://www.w3.org/TR/webdriver1/#dfn-back) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Back"))]
-    pub async fn back(&mut self) -> Result<(), error::CmdError> {
+    pub async fn back(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::GoBack).await?;
         Ok(())
     }
@@ -238,7 +238,7 @@ impl Client {
     ///
     /// See [9.4 Forward](https://www.w3.org/TR/webdriver1/#dfn-forward) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Forward"))]
-    pub async fn forward(&mut self) -> Result<(), error::CmdError> {
+    pub async fn forward(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::GoForward).await?;
         Ok(())
     }
@@ -247,7 +247,7 @@ impl Client {
     ///
     /// See [9.5 Refresh](https://www.w3.org/TR/webdriver1/#dfn-refresh) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Refresh"))]
-    pub async fn refresh(&mut self) -> Result<(), error::CmdError> {
+    pub async fn refresh(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::Refresh).await?;
         Ok(())
     }
@@ -256,7 +256,7 @@ impl Client {
     ///
     /// See [9.6 Get Title](https://www.w3.org/TR/webdriver1/#dfn-get-title) of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Title"))]
-    pub async fn title(&mut self) -> Result<String, error::CmdError> {
+    pub async fn title(&self) -> Result<String, error::CmdError> {
         let title = self.issue(WebDriverCommand::GetTitle).await?;
         if let Json::String(s) = title {
             Ok(s)
@@ -273,7 +273,7 @@ impl Client {
     /// See [10.1 Get Window Handle](https://www.w3.org/TR/webdriver1/#get-window-handle) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Window Handle"))]
-    pub async fn window(&mut self) -> Result<WindowHandle, error::CmdError> {
+    pub async fn window(&self) -> Result<WindowHandle, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetWindowHandle).await?;
         match res {
             Json::String(x) => Ok(x.try_into()?),
@@ -292,7 +292,7 @@ impl Client {
     /// See [10.2 Close Window](https://www.w3.org/TR/webdriver1/#close-window) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Close Window"))]
-    pub async fn close_window(&mut self) -> Result<(), error::CmdError> {
+    pub async fn close_window(&self) -> Result<(), error::CmdError> {
         let _res = self.issue(WebDriverCommand::CloseWindow).await?;
         Ok(())
     }
@@ -302,7 +302,7 @@ impl Client {
     /// See [10.3 Switch To Window](https://www.w3.org/TR/webdriver1/#switch-to-window) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Window"))]
-    pub async fn switch_to_window(&mut self, window: WindowHandle) -> Result<(), error::CmdError> {
+    pub async fn switch_to_window(&self, window: WindowHandle) -> Result<(), error::CmdError> {
         let params = webdriver::command::SwitchToWindowParameters {
             handle: window.into(),
         };
@@ -315,7 +315,7 @@ impl Client {
     /// See [10.4 Get Window Handles](https://www.w3.org/TR/webdriver1/#get-window-handles) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Window Handles"))]
-    pub async fn windows(&mut self) -> Result<Vec<WindowHandle>, error::CmdError> {
+    pub async fn windows(&self) -> Result<Vec<WindowHandle>, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetWindowHandles).await?;
         match res {
             Json::Array(handles) => handles
@@ -343,7 +343,7 @@ impl Client {
     /// See [11.5 New Window](https://w3c.github.io/webdriver/#dfn-new-window) of the editor's
     /// draft standard.
     #[cfg_attr(docsrs, doc(alias = "New Window"))]
-    pub async fn new_window(&mut self, as_tab: bool) -> Result<NewWindowResponse, error::CmdError> {
+    pub async fn new_window(&self, as_tab: bool) -> Result<NewWindowResponse, error::CmdError> {
         let type_hint = if as_tab { "tab" } else { "window" }.to_string();
         let type_hint = Some(type_hint);
         let params = webdriver::command::NewWindowParameters { type_hint };
@@ -377,12 +377,12 @@ impl Client {
     /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
-    pub async fn enter_frame(mut self, index: Option<u16>) -> Result<Client, error::CmdError> {
+    pub async fn enter_frame(&self, index: Option<u16>) -> Result<(), error::CmdError> {
         let params = webdriver::command::SwitchToFrameParameters {
             id: index.map(FrameId::Short),
         };
         self.issue(WebDriverCommand::SwitchToFrame(params)).await?;
-        Ok(self)
+        Ok(())
     }
 
     /// Switches to the parent of the frame the client is currently contained within.
@@ -390,9 +390,9 @@ impl Client {
     /// See [10.6 Switch To Parent Frame](https://www.w3.org/TR/webdriver1/#switch-to-parent-frame)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Parent Frame"))]
-    pub async fn enter_parent_frame(mut self) -> Result<Client, error::CmdError> {
+    pub async fn enter_parent_frame(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::SwitchToParentFrame).await?;
-        Ok(self)
+        Ok(())
     }
 
     /// Sets the x, y, width, and height properties of the current window.
@@ -401,7 +401,7 @@ impl Client {
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
     pub async fn set_window_rect(
-        &mut self,
+        &self,
         x: u32,
         y: u32,
         width: u32,
@@ -423,7 +423,7 @@ impl Client {
     /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
-    pub async fn get_window_rect(&mut self) -> Result<(u64, u64, u64, u64), error::CmdError> {
+    pub async fn get_window_rect(&self) -> Result<(u64, u64, u64, u64), error::CmdError> {
         match self.issue(WebDriverCommand::GetWindowRect).await? {
             Json::Object(mut obj) => {
                 let x = match obj.remove("x").and_then(|x| x.as_u64()) {
@@ -457,11 +457,7 @@ impl Client {
     /// See [10.7.2 Set Window Rect](https://www.w3.org/TR/webdriver1/#dfn-set-window-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
-    pub async fn set_window_size(
-        &mut self,
-        width: u32,
-        height: u32,
-    ) -> Result<(), error::CmdError> {
+    pub async fn set_window_size(&self, width: u32, height: u32) -> Result<(), error::CmdError> {
         let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
             x: None,
             y: None,
@@ -478,7 +474,7 @@ impl Client {
     /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
-    pub async fn get_window_size(&mut self) -> Result<(u64, u64), error::CmdError> {
+    pub async fn get_window_size(&self) -> Result<(u64, u64), error::CmdError> {
         let (_, _, width, height) = self.get_window_rect().await?;
         Ok((width, height))
     }
@@ -488,7 +484,7 @@ impl Client {
     /// See [10.7.2 Set Window Rect](https://www.w3.org/TR/webdriver1/#dfn-set-window-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Set Window Rect"))]
-    pub async fn set_window_position(&mut self, x: u32, y: u32) -> Result<(), error::CmdError> {
+    pub async fn set_window_position(&self, x: u32, y: u32) -> Result<(), error::CmdError> {
         let cmd = WebDriverCommand::SetWindowRect(webdriver::command::WindowRectParameters {
             x: Some(x as i32),
             y: Some(y as i32),
@@ -505,7 +501,7 @@ impl Client {
     /// See [10.7.1 Get Window Rect](https://www.w3.org/TR/webdriver1/#dfn-get-window-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Window Rect"))]
-    pub async fn get_window_position(&mut self) -> Result<(u64, u64), error::CmdError> {
+    pub async fn get_window_position(&self) -> Result<(u64, u64), error::CmdError> {
         let (x, y, _, _) = self.get_window_rect().await?;
         Ok((x, y))
     }
@@ -514,7 +510,7 @@ impl Client {
     ///
     /// See [10.7.3 Maximize Window](https://www.w3.org/TR/webdriver1/#dfn-maximize-window) of the
     /// WebDriver standard.
-    pub async fn maximize_window(&mut self) -> Result<(), error::CmdError> {
+    pub async fn maximize_window(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::MaximizeWindow).await?;
         Ok(())
     }
@@ -523,7 +519,7 @@ impl Client {
     ///
     /// See [10.7.4 Minimize Window](https://www.w3.org/TR/webdriver1/#dfn-minimize-window) of the
     /// WebDriver standard.
-    pub async fn minimize_window(&mut self) -> Result<(), error::CmdError> {
+    pub async fn minimize_window(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::MinimizeWindow).await?;
         Ok(())
     }
@@ -532,7 +528,7 @@ impl Client {
     ///
     /// See [10.7.5 Fullscreen Window](https://www.w3.org/TR/webdriver1/#dfn-fullscreen-window) of the
     /// WebDriver standard.
-    pub async fn fullscreen_window(&mut self) -> Result<(), error::CmdError> {
+    pub async fn fullscreen_window(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::FullscreenWindow).await?;
         Ok(())
     }
@@ -545,7 +541,7 @@ impl Client {
     /// See [12.2 Find Element](https://www.w3.org/TR/webdriver1/#find-element) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Find Element"))]
-    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+    pub async fn find(&self, search: Locator<'_>) -> Result<Element, error::CmdError> {
         self.by(search.into_parameters()).await
     }
 
@@ -554,7 +550,7 @@ impl Client {
     /// See [12.3 Find Elements](https://www.w3.org/TR/webdriver1/#find-elements) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Find Elements"))]
-    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
+    pub async fn find_all(&self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
         let res = self
             .issue(WebDriverCommand::FindElements(search.into_parameters()))
             .await?;
@@ -580,7 +576,7 @@ impl Client {
     /// See [12.6 Get Active Element](https://www.w3.org/TR/webdriver1/#dfn-get-active-element) of
     /// the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Active Element"))]
-    pub async fn active_element(&mut self) -> Result<Element, error::CmdError> {
+    pub async fn active_element(&self) -> Result<Element, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetActiveElement).await?;
         let e = self.parse_lookup(res)?;
         Ok(Element {
@@ -592,7 +588,7 @@ impl Client {
     /// Locate a form on the page.
     ///
     /// Through the returned `Form`, HTML forms can be filled out and submitted.
-    pub async fn form(&mut self, search: Locator<'_>) -> Result<Form, error::CmdError> {
+    pub async fn form(&self, search: Locator<'_>) -> Result<Form, error::CmdError> {
         let l = search.into_parameters();
         let res = self.issue(WebDriverCommand::FindElement(l)).await?;
         let f = self.parse_lookup(res)?;
@@ -610,7 +606,7 @@ impl Client {
     /// See [15.1 Get Page Source](https://www.w3.org/TR/webdriver1/#dfn-get-page-source) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Page Source"))]
-    pub async fn source(&mut self) -> Result<String, error::CmdError> {
+    pub async fn source(&self) -> Result<String, error::CmdError> {
         let src = self.issue(WebDriverCommand::GetPageSource).await?;
         if let Some(src) = src.as_str() {
             Ok(src.to_string())
@@ -631,7 +627,7 @@ impl Client {
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Execute Script"))]
     pub async fn execute(
-        &mut self,
+        &self,
         script: &str,
         mut args: Vec<Json>,
     ) -> Result<Json, error::CmdError> {
@@ -677,7 +673,7 @@ impl Client {
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Execute Async Script"))]
     pub async fn execute_async(
-        &mut self,
+        &self,
         script: &str,
         mut args: Vec<Json>,
     ) -> Result<Json, error::CmdError> {
@@ -718,7 +714,7 @@ impl Client {
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Perform Actions"))]
     pub async fn perform_actions(
-        &mut self,
+        &self,
         actions: impl Into<Actions>,
     ) -> Result<(), error::CmdError> {
         let params = webdriver::command::ActionsParameters {
@@ -734,7 +730,7 @@ impl Client {
     /// See [17.6 Release Actions](https://www.w3.org/TR/webdriver1/#release-actions) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Release Actions"))]
-    pub async fn release_actions(&mut self) -> Result<(), error::CmdError> {
+    pub async fn release_actions(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::ReleaseActions).await?;
         Ok(())
     }
@@ -747,7 +743,7 @@ impl Client {
     /// See [18.1 Dismiss Alert](https://www.w3.org/TR/webdriver1/#dismiss-alert) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Dismiss Alert"))]
-    pub async fn dismiss_alert(&mut self) -> Result<(), error::CmdError> {
+    pub async fn dismiss_alert(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DismissAlert).await?;
         Ok(())
     }
@@ -757,7 +753,7 @@ impl Client {
     /// See [18.2 Accept Alert](https://www.w3.org/TR/webdriver1/#accept-alert) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Accept Alert"))]
-    pub async fn accept_alert(&mut self) -> Result<(), error::CmdError> {
+    pub async fn accept_alert(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::AcceptAlert).await?;
         Ok(())
     }
@@ -767,7 +763,7 @@ impl Client {
     /// See [18.3 Get Alert Text](https://www.w3.org/TR/webdriver1/#get-alert-text) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Alert Text"))]
-    pub async fn get_alert_text(&mut self) -> Result<String, error::CmdError> {
+    pub async fn get_alert_text(&self) -> Result<String, error::CmdError> {
         let res = self.issue(WebDriverCommand::GetAlertText).await?;
         if let Json::String(s) = res {
             Ok(s)
@@ -781,7 +777,7 @@ impl Client {
     /// See [18.4 Send Alert Text](https://www.w3.org/TR/webdriver1/#send-alert-text) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Send Alert Text"))]
-    pub async fn send_alert_text(&mut self, text: &str) -> Result<(), error::CmdError> {
+    pub async fn send_alert_text(&self, text: &str) -> Result<(), error::CmdError> {
         let params = SendKeysParameters {
             text: text.to_string(),
         };
@@ -797,7 +793,7 @@ impl Client {
     /// See [19.1 Take Screenshot](https://www.w3.org/TR/webdriver1/#dfn-take-screenshot) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Take Screenshot"))]
-    pub async fn screenshot(&mut self) -> Result<Vec<u8>, error::CmdError> {
+    pub async fn screenshot(&self) -> Result<Vec<u8>, error::CmdError> {
         let src = self.issue(WebDriverCommand::TakeScreenshot).await?;
         if let Some(src) = src.as_str() {
             base64::decode(src).map_err(error::CmdError::ImageDecodeError)
@@ -812,10 +808,7 @@ impl Client {
     /// Screenshot](https://www.w3.org/TR/webdriver1/#dfn-take-element-screenshot) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Take Element Screenshot"))]
-    pub async fn screenshot_element(
-        &mut self,
-        element: Element,
-    ) -> Result<Vec<u8>, error::CmdError> {
+    pub async fn screenshot_element(&self, element: Element) -> Result<Vec<u8>, error::CmdError> {
         let src = self
             .issue(WebDriverCommand::TakeElementScreenshot(element.element))
             .await?;
@@ -839,9 +832,9 @@ impl Client {
         since = "0.17.5",
         note = "This method might block forever. Please use client.wait().on(...) instead. You can still wait forever using: client.wait().forever().on(...)"
     )]
-    pub async fn wait_for<F, FF>(&mut self, mut is_ready: F) -> Result<(), error::CmdError>
+    pub async fn wait_for<F, FF>(&self, mut is_ready: F) -> Result<(), error::CmdError>
     where
-        F: FnMut(&mut Client) -> FF,
+        F: FnMut(&Client) -> FF,
         FF: Future<Output = Result<bool, error::CmdError>>,
     {
         while !is_ready(self).await? {}
@@ -858,7 +851,7 @@ impl Client {
         since = "0.17.5",
         note = "This method might block forever. Please use client.wait().on(locator) instead. You can still wait forever using: client.wait().forever().on(locator)"
     )]
-    pub async fn wait_for_find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+    pub async fn wait_for_find(&self, search: Locator<'_>) -> Result<Element, error::CmdError> {
         self.wait().forever().for_element(search).await
     }
 
@@ -872,7 +865,7 @@ impl Client {
         note = "This method might block forever and has a chance of randomly blocking. Please use client.wait().on(url) instead, to check if you navigated successfully to the new URL."
     )]
     pub async fn wait_for_navigation(
-        &mut self,
+        &self,
         current: Option<url::Url>,
     ) -> Result<(), error::CmdError> {
         let current = match current {
@@ -885,7 +878,7 @@ impl Client {
             // TODO: get rid of this clone
             let current = current.clone();
             // TODO: and this one too
-            let mut c = c.clone();
+            let c = c.clone();
             async move { Ok(c.current_url().await? != current) }
         })
         .await
@@ -898,7 +891,7 @@ impl Client {
     ///
     /// Calling this method is equivalent to calling `with_raw_client_for` with an empty closure.
     pub async fn raw_client_for(
-        &mut self,
+        &self,
         method: Method,
         url: &str,
     ) -> Result<hyper::Response<hyper::Body>, error::CmdError> {
@@ -912,7 +905,7 @@ impl Client {
     /// Before the HTTP request is issued, the given `before` closure will be called with a handle
     /// to the `Request` about to be sent.
     pub async fn with_raw_client_for<F>(
-        &mut self,
+        &self,
         method: Method,
         url: &str,
         before: F,
@@ -1016,11 +1009,11 @@ impl Client {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), fantoccini::error::CmdError> {
     /// # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-    /// # let mut client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # let client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
     /// # #[cfg(feature = "rustls-tls")]
-    /// # let mut client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # let client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
     /// # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-    /// # let mut client: fantoccini::Client = unreachable!("no tls provider available");
+    /// # let client: fantoccini::Client = unreachable!("no tls provider available");
     /// // -- snip wrapper code --
     /// let button = client.wait().for_element(Locator::Css(
     ///     r#"a.button-download[href="/learn/get-started"]"#,
@@ -1031,7 +1024,7 @@ impl Client {
     /// ```
     ///
     /// Also see: [`crate::wait`].
-    pub fn wait(&mut self) -> Wait<'_> {
+    pub fn wait(&self) -> Wait<'_> {
         Wait::new(self)
     }
 }
@@ -1039,7 +1032,7 @@ impl Client {
 /// Helper methods
 impl Client {
     pub(crate) async fn by(
-        &mut self,
+        &self,
         locator: webdriver::command::LocatorParameters,
     ) -> Result<Element, error::CmdError> {
         let res = self.issue(WebDriverCommand::FindElement(locator)).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,12 +121,12 @@ impl Client {
     /// `Handle` given when creating this `Client`. This in turn means that any errors will be
     /// dropped.
     ///
-    /// This function is safe to call multiple times, but once it has been called on one instance
-    /// of a `Client`, all requests to other instances of that `Client` will fail.
+    /// Once it has been called on one instance of a `Client`, all requests to other instances
+    /// of that `Client` will fail.
     ///
     /// This function may be useful in conjunction with `raw_client_for`, as it allows you to close
     /// the automated browser window while doing e.g., a large download.
-    pub async fn close(&self) -> Result<(), error::CmdError> {
+    pub async fn close(self) -> Result<(), error::CmdError> {
         self.issue(Cmd::Shutdown).await?;
         Ok(())
     }
@@ -795,23 +795,6 @@ impl Client {
     #[cfg_attr(docsrs, doc(alias = "Take Screenshot"))]
     pub async fn screenshot(&self) -> Result<Vec<u8>, error::CmdError> {
         let src = self.issue(WebDriverCommand::TakeScreenshot).await?;
-        if let Some(src) = src.as_str() {
-            base64::decode(src).map_err(error::CmdError::ImageDecodeError)
-        } else {
-            Err(error::CmdError::NotW3C(src))
-        }
-    }
-
-    /// Get a PNG-encoded screenshot of an element.
-    ///
-    /// See [19.2 Take Element
-    /// Screenshot](https://www.w3.org/TR/webdriver1/#dfn-take-element-screenshot) of the WebDriver
-    /// standard.
-    #[cfg_attr(docsrs, doc(alias = "Take Element Screenshot"))]
-    pub async fn screenshot_element(&self, element: Element) -> Result<Vec<u8>, error::CmdError> {
-        let src = self
-            .issue(WebDriverCommand::TakeElementScreenshot(element.element))
-            .await?;
         if let Some(src) = src.as_str() {
             base64::decode(src).map_err(error::CmdError::ImageDecodeError)
         } else {

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -136,7 +136,7 @@ impl Client {
     ///
     /// See [16.1 Get All Cookies](https://www.w3.org/TR/webdriver1/#get-all-cookies) of the
     /// WebDriver standard.
-    pub async fn get_all_cookies(&mut self) -> Result<Vec<Cookie<'static>>, error::CmdError> {
+    pub async fn get_all_cookies(&self) -> Result<Vec<Cookie<'static>>, error::CmdError> {
         let resp = self.issue(WebDriverCommand::GetCookies).await?;
 
         let webdriver_cookies: Vec<WebDriverCookie> = serde_json::from_value(resp)?;
@@ -152,10 +152,7 @@ impl Client {
     ///
     /// See [16.2 Get Named Cookie](https://www.w3.org/TR/webdriver1/#get-named-cookie) of the
     /// WebDriver standard.
-    pub async fn get_named_cookie(
-        &mut self,
-        name: &str,
-    ) -> Result<Cookie<'static>, error::CmdError> {
+    pub async fn get_named_cookie(&self, name: &str) -> Result<Cookie<'static>, error::CmdError> {
         let resp = self
             .issue(WebDriverCommand::GetNamedCookie(name.to_string()))
             .await?;
@@ -167,7 +164,7 @@ impl Client {
     ///
     /// See [16.3 Add Cookie](https://www.w3.org/TR/webdriver1/#add-cookie) of the
     /// WebDriver standard.
-    pub async fn add_cookie(&mut self, cookie: Cookie<'static>) -> Result<(), error::CmdError> {
+    pub async fn add_cookie(&self, cookie: Cookie<'static>) -> Result<(), error::CmdError> {
         let webdriver_cookie: WebDriverCookie = cookie.into();
         self.issue(WebDriverCommand::AddCookie(webdriver_cookie.into_params()))
             .await?;
@@ -178,7 +175,7 @@ impl Client {
     ///
     /// See [16.4 Delete Cookie](https://www.w3.org/TR/webdriver1/#delete-cookie) of the
     /// WebDriver standard.
-    pub async fn delete_cookie(&mut self, name: &str) -> Result<(), error::CmdError> {
+    pub async fn delete_cookie(&self, name: &str) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DeleteCookie(name.to_string()))
             .await
             .map(|_| ())
@@ -188,7 +185,7 @@ impl Client {
     ///
     /// See [16.5 Delete All Cookies](https://www.w3.org/TR/webdriver1/#delete-all-cookies) of the
     /// WebDriver standard.
-    pub async fn delete_all_cookies(&mut self) -> Result<(), error::CmdError> {
+    pub async fn delete_all_cookies(&self) -> Result<(), error::CmdError> {
         self.issue(WebDriverCommand::DeleteCookies)
             .await
             .map(|_| ())

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -398,6 +398,28 @@ impl Element {
     }
 }
 
+/// [Screen Capture](https://www.w3.org/TR/webdriver1/#screen-capture)
+impl Element {
+    /// Get a PNG-encoded screenshot of this element.
+    ///
+    /// See [19.2 Take Element Screenshot](https://www.w3.org/TR/webdriver1/#dfn-take-element-screenshot) of the WebDriver
+    /// standard.
+    #[cfg_attr(docsrs, doc(alias = "Take Element Screenshot"))]
+    pub async fn screenshot(&self) -> Result<Vec<u8>, error::CmdError> {
+        let src = self
+            .client
+            .issue(WebDriverCommand::TakeElementScreenshot(
+                self.element.clone(),
+            ))
+            .await?;
+        if let Some(src) = src.as_str() {
+            base64::decode(src).map_err(error::CmdError::ImageDecodeError)
+        } else {
+            Err(error::CmdError::NotW3C(src))
+        }
+    }
+}
+
 /// Higher-level operations.
 impl Element {
     /// Follow the `href` target of the element matching the given CSS selector *without* causing a

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -103,18 +103,14 @@ impl Element {
     /// See [10.5 Switch To Frame](https://www.w3.org/TR/webdriver1/#switch-to-frame) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Switch To Frame"))]
-    pub async fn enter_frame(self) -> Result<Client, error::CmdError> {
-        let Self {
-            mut client,
-            element,
-        } = self;
+    pub async fn enter_frame(&self) -> Result<(), error::CmdError> {
         let params = webdriver::command::SwitchToFrameParameters {
-            id: Some(FrameId::Element(element)),
+            id: Some(FrameId::Element(self.element.clone())),
         };
-        client
+        self.client
             .issue(WebDriverCommand::SwitchToFrame(params))
             .await?;
-        Ok(client)
+        Ok(())
     }
 }
 
@@ -126,7 +122,7 @@ impl Element {
     /// Element](https://www.w3.org/TR/webdriver1/#find-element-from-element) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Find Element From Element"))]
-    pub async fn find(&mut self, search: Locator<'_>) -> Result<Element, error::CmdError> {
+    pub async fn find(&self, search: Locator<'_>) -> Result<Element, error::CmdError> {
         let res = self
             .client
             .issue(WebDriverCommand::FindElementElement(
@@ -147,7 +143,7 @@ impl Element {
     /// Element](https://www.w3.org/TR/webdriver1/#find-elements-from-element) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Find Elements From Element"))]
-    pub async fn find_all(&mut self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
+    pub async fn find_all(&self, search: Locator<'_>) -> Result<Vec<Element>, error::CmdError> {
         let res = self
             .client
             .issue(WebDriverCommand::FindElementElements(
@@ -172,7 +168,7 @@ impl Element {
     ///
     /// See [13.1 Is Element Selected](https://www.w3.org/TR/webdriver1/#is-element-selected)
     /// of the WebDriver standard.
-    pub async fn is_selected(&mut self) -> Result<bool, error::CmdError> {
+    pub async fn is_selected(&self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsSelected(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -184,7 +180,7 @@ impl Element {
     ///
     /// See [13.8 Is Element Enabled](https://www.w3.org/TR/webdriver1/#is-element-enabled)
     /// of the WebDriver standard.
-    pub async fn is_enabled(&mut self) -> Result<bool, error::CmdError> {
+    pub async fn is_enabled(&self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsEnabled(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -196,7 +192,7 @@ impl Element {
     ///
     /// See [Element Displayedness](https://www.w3.org/TR/webdriver1/#element-displayedness)
     /// of the WebDriver standard.
-    pub async fn is_displayed(&mut self) -> Result<bool, error::CmdError> {
+    pub async fn is_displayed(&self) -> Result<bool, error::CmdError> {
         let cmd = WebDriverCommand::IsDisplayed(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::Bool(v) => Ok(v),
@@ -213,7 +209,7 @@ impl Element {
     ///
     /// [attribute]: https://dom.spec.whatwg.org/#concept-attribute
     #[cfg_attr(docsrs, doc(alias = "Get Element Attribute"))]
-    pub async fn attr(&mut self, attribute: &str) -> Result<Option<String>, error::CmdError> {
+    pub async fn attr(&self, attribute: &str) -> Result<Option<String>, error::CmdError> {
         let cmd =
             WebDriverCommand::GetElementAttribute(self.element.clone(), attribute.to_string());
         match self.client.issue(cmd).await? {
@@ -234,7 +230,7 @@ impl Element {
     ///
     /// [property]: https://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1
     #[cfg_attr(docsrs, doc(alias = "Get Element Property"))]
-    pub async fn prop(&mut self, prop: &str) -> Result<Option<String>, error::CmdError> {
+    pub async fn prop(&self, prop: &str) -> Result<Option<String>, error::CmdError> {
         let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(Some(v)),
@@ -253,7 +249,7 @@ impl Element {
     ///
     /// [computed value]: https://drafts.csswg.org/css-cascade-4/#computed-value
     #[cfg_attr(docsrs, doc(alias = "Get Element CSS Value"))]
-    pub async fn css_value(&mut self, prop: &str) -> Result<String, error::CmdError> {
+    pub async fn css_value(&self, prop: &str) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetCSSValue(self.element.clone(), prop.to_string());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(v),
@@ -266,7 +262,7 @@ impl Element {
     /// See [13.5 Get Element Text](https://www.w3.org/TR/webdriver1/#get-element-text)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Element Text"))]
-    pub async fn text(&mut self) -> Result<String, error::CmdError> {
+    pub async fn text(&self) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetElementText(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(v),
@@ -279,7 +275,7 @@ impl Element {
     /// See [13.6 Get Element Tag Name](https://www.w3.org/TR/webdriver1/#get-element-tag-name)
     /// of the WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Element Tag Name"))]
-    pub async fn tag_name(&mut self) -> Result<String, error::CmdError> {
+    pub async fn tag_name(&self) -> Result<String, error::CmdError> {
         let cmd = WebDriverCommand::GetElementTagName(self.element.clone());
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(v),
@@ -292,7 +288,7 @@ impl Element {
     /// See [13.7 Get Element Rect](https://www.w3.org/TR/webdriver1/#dfn-get-element-rect) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Get Element Rect"))]
-    pub async fn rectangle(&mut self) -> Result<(f64, f64, f64, f64), error::CmdError> {
+    pub async fn rectangle(&self) -> Result<(f64, f64, f64, f64), error::CmdError> {
         match self
             .client
             .issue(WebDriverCommand::GetElementRect(self.element.clone()))
@@ -338,7 +334,7 @@ impl Element {
     /// `<div id="foo"><hr /></div>` would be returned instead.
     #[cfg_attr(docsrs, doc(alias = "innerHTML"))]
     #[cfg_attr(docsrs, doc(alias = "outerHTML"))]
-    pub async fn html(&mut self, inner: bool) -> Result<String, error::CmdError> {
+    pub async fn html(&self, inner: bool) -> Result<String, error::CmdError> {
         let prop = if inner { "innerHTML" } else { "outerHTML" };
         Ok(self.prop(prop).await?.unwrap())
     }
@@ -348,17 +344,15 @@ impl Element {
 impl Element {
     /// Simulate the user clicking on this element.
     ///
-    /// Note that since this *may* result in navigation, we give up the handle to the element.
-    ///
     /// See [14.1 Element Click](https://www.w3.org/TR/webdriver1/#element-click) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Element Click"))]
-    pub async fn click(mut self) -> Result<Client, error::CmdError> {
-        let cmd = WebDriverCommand::ElementClick(self.element);
+    pub async fn click(&self) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::ElementClick(self.element.clone());
         let r = self.client.issue(cmd).await?;
         if r.is_null() || r.as_object().map(|o| o.is_empty()).unwrap_or(false) {
             // geckodriver returns {} :(
-            Ok(self.client)
+            Ok(())
         } else {
             Err(error::CmdError::NotW3C(r))
         }
@@ -369,7 +363,7 @@ impl Element {
     /// See [14.2 Element Clear](https://www.w3.org/TR/webdriver1/#element-clear) of the WebDriver
     /// standard.
     #[cfg_attr(docsrs, doc(alias = "Element Clear"))]
-    pub async fn clear(&mut self) -> Result<(), error::CmdError> {
+    pub async fn clear(&self) -> Result<(), error::CmdError> {
         let cmd = WebDriverCommand::ElementClear(self.element.clone());
         let r = self.client.issue(cmd).await?;
         if r.is_null() {
@@ -388,7 +382,7 @@ impl Element {
     /// See [14.3 Element Send Keys](https://www.w3.org/TR/webdriver1/#element-send-keys) of the
     /// WebDriver standard.
     #[cfg_attr(docsrs, doc(alias = "Element Send Keys"))]
-    pub async fn send_keys(&mut self, text: &str) -> Result<(), error::CmdError> {
+    pub async fn send_keys(&self, text: &str) -> Result<(), error::CmdError> {
         let cmd = WebDriverCommand::ElementSendKeys(
             self.element.clone(),
             webdriver::command::SendKeysParameters {
@@ -408,10 +402,8 @@ impl Element {
 impl Element {
     /// Follow the `href` target of the element matching the given CSS selector *without* causing a
     /// click interaction.
-    ///
-    /// Note that since this *may* result in navigation, we give up the handle to the element.
-    pub async fn follow(mut self) -> Result<Client, error::CmdError> {
-        let cmd = WebDriverCommand::GetElementAttribute(self.element, "href".to_string());
+    pub async fn follow(&self) -> Result<(), error::CmdError> {
+        let cmd = WebDriverCommand::GetElementAttribute(self.element.clone(), "href".to_string());
         let href = self.client.issue(cmd).await?;
         let href = match href {
             Json::String(v) => v,
@@ -430,19 +422,19 @@ impl Element {
         let url = self.client.current_url_().await?;
         let href = url.join(&href)?;
         self.client.goto(href.as_str()).await?;
-        Ok(self.client)
+        Ok(())
     }
 
     /// Find and click an `<option>` child element by a locator.
     ///
     /// This method clicks the first `<option>` element that is found.
     /// If the element wasn't found, [`CmdError::NoSuchElement`](error::CmdError::NoSuchElement) will be issued.
-    pub async fn select_by(mut self, locator: Locator<'_>) -> Result<Client, error::CmdError> {
+    pub async fn select_by(&self, locator: Locator<'_>) -> Result<(), error::CmdError> {
         self.find(locator).await?.click().await
     }
 
     /// Find and click an `option` child element by its `value` attribute.
-    pub async fn select_by_value(self, value: &str) -> Result<Client, error::CmdError> {
+    pub async fn select_by_value(&self, value: &str) -> Result<(), error::CmdError> {
         self.select_by(Locator::Css(&format!("option[value='{}']", value)))
             .await
     }
@@ -457,7 +449,7 @@ impl Element {
     /// in the form, or if it there are stray `<option>` in the form.
     ///
     /// The indexing in this method is 0-based.
-    pub async fn select_by_index(self, index: usize) -> Result<Client, error::CmdError> {
+    pub async fn select_by_index(&self, index: usize) -> Result<(), error::CmdError> {
         self.select_by(Locator::Css(&format!("option:nth-of-type({})", index + 1)))
             .await
     }
@@ -468,7 +460,7 @@ impl Element {
     /// It also doesn't make any normalizations before match.
     ///
     /// [example]: https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/py/selenium/webdriver/support/select.py#L67
-    pub async fn select_by_label(self, label: &str) -> Result<Client, error::CmdError> {
+    pub async fn select_by_label(&self, label: &str) -> Result<(), error::CmdError> {
         self.select_by(Locator::XPath(&format!(r".//option[.='{}']", label)))
             .await
     }
@@ -483,11 +475,7 @@ impl Form {
 
 impl Form {
     /// Find a form input using the given `locator` and set its value to `value`.
-    pub async fn set(
-        &mut self,
-        locator: Locator<'_>,
-        value: &str,
-    ) -> Result<Self, error::CmdError> {
+    pub async fn set(&self, locator: Locator<'_>, value: &str) -> Result<Self, error::CmdError> {
         let locator =
             WebDriverCommand::FindElementElement(self.form.clone(), locator.into_parameters());
         let value = Json::from(value);
@@ -516,7 +504,7 @@ impl Form {
     }
 
     /// Find a form input with the given `name` and set its value to `value`.
-    pub async fn set_by_name(&mut self, field: &str, value: &str) -> Result<Self, error::CmdError> {
+    pub async fn set_by_name(&self, field: &str, value: &str) -> Result<Self, error::CmdError> {
         let locator = format!("[name='{}']", field);
         let locator = Locator::Css(&locator);
         self.set(locator, value).await
@@ -527,7 +515,7 @@ impl Form {
     /// Submit this form using the first available submit button.
     ///
     /// `false` is returned if no submit button was not found.
-    pub async fn submit(self) -> Result<Client, error::CmdError> {
+    pub async fn submit(&self) -> Result<(), error::CmdError> {
         self.submit_with(Locator::Css("input[type=submit],button[type=submit]"))
             .await
     }
@@ -535,8 +523,9 @@ impl Form {
     /// Submit this form using the button matched by the given selector.
     ///
     /// `false` is returned if a matching button was not found.
-    pub async fn submit_with(mut self, button: Locator<'_>) -> Result<Client, error::CmdError> {
-        let locator = WebDriverCommand::FindElementElement(self.form, button.into_parameters());
+    pub async fn submit_with(&self, button: Locator<'_>) -> Result<(), error::CmdError> {
+        let locator =
+            WebDriverCommand::FindElementElement(self.form.clone(), button.into_parameters());
         let res = self.client.issue(locator).await?;
         let submit = self.client.parse_lookup(res)?;
         let res = self
@@ -545,7 +534,7 @@ impl Form {
             .await?;
         if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
             // geckodriver returns {} :(
-            Ok(self.client)
+            Ok(())
         } else {
             Err(error::CmdError::NotW3C(res))
         }
@@ -554,7 +543,7 @@ impl Form {
     /// Submit this form using the form submit button with the given label (case-insensitive).
     ///
     /// `false` is returned if a matching button was not found.
-    pub async fn submit_using(self, button_label: &str) -> Result<Client, error::CmdError> {
+    pub async fn submit_using(&self, button_label: &str) -> Result<(), error::CmdError> {
         let escaped = button_label.replace('\\', "\\\\").replace('"', "\\\"");
         let btn = format!(
             "input[type=submit][value=\"{}\" i],\
@@ -572,7 +561,7 @@ impl Form {
     ///
     /// Note that since no button is actually clicked, the `name=value` pair for the submit button
     /// will not be submitted. This can be circumvented by using `submit_sneaky` instead.
-    pub async fn submit_direct(mut self) -> Result<Client, error::CmdError> {
+    pub async fn submit_direct(&self) -> Result<(), error::CmdError> {
         let mut args = vec![via_json!(&self.form)];
         self.client.fixup_elements(&mut args);
         // some sites are silly, and name their submit button "submit". this ends up overwriting
@@ -591,7 +580,7 @@ impl Form {
             .await?;
         if res.is_null() || res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
             // geckodriver returns {} :(
-            Ok(self.client)
+            Ok(())
         } else {
             Err(error::CmdError::NotW3C(res))
         }
@@ -603,11 +592,7 @@ impl Form {
     /// However, it will *also* inject a hidden input element on the page that carries the given
     /// `field=value` mapping. This allows you to emulate the form data as it would have been *if*
     /// the submit button was indeed clicked.
-    pub async fn submit_sneaky(
-        mut self,
-        field: &str,
-        value: &str,
-    ) -> Result<Client, error::CmdError> {
+    pub async fn submit_sneaky(&self, field: &str, value: &str) -> Result<(), error::CmdError> {
         let mut args = vec![via_json!(&self.form), Json::from(field), Json::from(value)];
         self.client.fixup_elements(&mut args);
         let cmd = webdriver::command::JavascriptCommandParameters {
@@ -627,12 +612,7 @@ impl Form {
             .await?;
         if res.is_null() | res.as_object().map(|o| o.is_empty()).unwrap_or(false) {
             // geckodriver returns {} :(
-            Form {
-                form: self.form,
-                client: self.client,
-            }
-            .submit_direct()
-            .await
+            self.submit_direct().await
         } else {
             Err(error::CmdError::NotW3C(res))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,12 @@
 //! async fn main() -> Result<(), fantoccini::error::CmdError> {
 //!     // Connecting using "native" TLS (with feature `native-tls`; on by default)
 //!     # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-//!     let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//!     let c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //!     // Connecting using Rustls (with feature `rustls-tls`)
 //!     # #[cfg(feature = "rustls-tls")]
-//!     let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//!     let c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //!     # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-//!     # let mut c: fantoccini::Client = unreachable!("no tls provider available");
+//!     # let c: fantoccini::Client = unreachable!("no tls provider available");
 //!
 //!     // first, go to the Wikipedia page for Foobar
 //!     c.goto("https://en.wikipedia.org/wiki/Foobar").await?;
@@ -74,16 +74,16 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), fantoccini::error::CmdError> {
 //! # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-//! # let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(feature = "rustls-tls")]
-//! # let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-//! # let mut c: fantoccini::Client = unreachable!("no tls provider available");
+//! # let c: fantoccini::Client = unreachable!("no tls provider available");
 //! // -- snip wrapper code --
 //! // go to the Wikipedia frontpage this time
 //! c.goto("https://www.wikipedia.org/").await?;
 //! // find the search form, fill it out, and submit it
-//! let mut f = c.form(Locator::Css("#search-form")).await?;
+//! let f = c.form(Locator::Css("#search-form")).await?;
 //! f.set_by_name("search", "foobar").await?
 //!  .submit().await?;
 //!
@@ -103,16 +103,16 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), fantoccini::error::CmdError> {
 //! # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-//! # let mut c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let c = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(feature = "rustls-tls")]
-//! # let mut c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let c = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-//! # let mut c: fantoccini::Client = unreachable!("no tls provider available");
+//! # let c: fantoccini::Client = unreachable!("no tls provider available");
 //! // -- snip wrapper code --
 //! // go back to the frontpage
 //! c.goto("https://www.wikipedia.org/").await?;
 //! // find the source for the Wikipedia globe
-//! let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
+//! let img = c.find(Locator::Css("img.central-featured-logo")).await?;
 //! let src = img.attr("src").await?.expect("image should have a src");
 //! // now build a raw HTTP client request (which also has all current cookies)
 //! let raw = img.client().raw_client_for(hyper::Method::GET, &src).await?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,7 +48,7 @@ pub(crate) struct Task {
 }
 
 impl Client {
-    pub(crate) fn issue<C>(&mut self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
+    pub(crate) fn issue<C>(&self, cmd: C) -> impl Future<Output = Result<Json, error::CmdError>>
     where
         C: Into<Cmd>,
     {
@@ -317,17 +317,13 @@ where
                 Err(error::NewSessionError::NotW3C(Json::String(v)))
             }
             Err(error::CmdError::Standard(
-                e
-                @
-                error::WebDriver {
+                e @ error::WebDriver {
                     error: ErrorStatus::SessionNotCreated,
                     ..
                 },
             )) => Err(error::NewSessionError::SessionNotCreated(e)),
             Err(error::CmdError::Standard(
-                e
-                @
-                error::WebDriver {
+                e @ error::WebDriver {
                     error: ErrorStatus::UnknownError,
                     ..
                 },
@@ -369,7 +365,7 @@ where
         });
 
         // now that the session is running, let's do the handshake
-        let mut client = Client {
+        let client = Client {
             tx: tx.clone(),
             is_legacy: false,
         };

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -25,11 +25,11 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), fantoccini::error::CmdError> {
 //! # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-//! # let mut client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(feature = "rustls-tls")]
-//! # let mut client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+//! # let client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
 //! # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-//! # let mut client: fantoccini::Client = unreachable!("no tls provider available");
+//! # let client: fantoccini::Client = unreachable!("no tls provider available");
 //! // -- snip wrapper code --
 //! let button = client.wait().for_element(Locator::Css(
 //!     r#"a.button-download[href="/learn/get-started"]"#,
@@ -56,7 +56,7 @@ const DEFAULT_PERIOD: Duration = Duration::from_millis(250);
 /// Used for setting up a wait operation on the client.
 #[derive(Debug)]
 pub struct Wait<'c> {
-    client: &'c mut Client,
+    client: &'c Client,
     timeout: Option<Duration>,
     period: Duration,
 }
@@ -90,11 +90,11 @@ impl<'c> Wait<'c> {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), fantoccini::error::CmdError> {
     /// # #[cfg(all(feature = "native-tls", not(feature = "rustls-tls")))]
-    /// # let mut client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # let client = ClientBuilder::native().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
     /// # #[cfg(feature = "rustls-tls")]
-    /// # let mut client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
+    /// # let client = ClientBuilder::rustls().connect("http://localhost:4444").await.expect("failed to connect to WebDriver");
     /// # #[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-    /// # let mut client: fantoccini::Client = unreachable!("no tls provider available");
+    /// # let client: fantoccini::Client = unreachable!("no tls provider available");
     /// // -- snip wrapper code --
     /// let button = client.wait().for_element(Locator::Css(
     ///     r#"a.button-download[href="/learn/get-started"]"#,
@@ -103,7 +103,7 @@ impl<'c> Wait<'c> {
     /// # client.close().await
     /// # }
     /// ```
-    pub fn new(client: &'c mut Client) -> Self {
+    pub fn new(client: &'c Client) -> Self {
         Self {
             client,
             timeout: Some(DEFAULT_TIMEOUT),

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -12,7 +12,7 @@ use time::Instant;
 
 mod common;
 
-async fn actions_null(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn actions_null(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     let null_actions = NullActions::new("null".to_string()).pause(Duration::from_secs(1));
@@ -22,7 +22,7 @@ async fn actions_null(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn actions_key(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn actions_key(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 
@@ -33,7 +33,7 @@ async fn actions_key(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     assert!(now.elapsed().as_seconds_f64() >= 1.0);
 
     // Test key down/up.
-    let mut elem = c.find(Locator::Id("text-input")).await?;
+    let elem = c.find(Locator::Id("text-input")).await?;
     elem.send_keys("a").await?;
     assert_eq!(elem.prop("value").await?.unwrap(), "a");
 
@@ -46,12 +46,12 @@ async fn actions_key(mut c: Client, port: u16) -> Result<(), error::CmdError> {
         });
     elem.click().await?;
     c.perform_actions(key_actions).await?;
-    let mut elem = c.find(Locator::Id("text-input")).await?;
+    let elem = c.find(Locator::Id("text-input")).await?;
     assert_eq!(elem.prop("value").await?.unwrap(), "");
     Ok(())
 }
 
-async fn actions_mouse(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn actions_mouse(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 
@@ -84,14 +84,14 @@ async fn actions_mouse(mut c: Client, port: u16) -> Result<(), error::CmdError> 
     Ok(())
 }
 
-async fn actions_mouse_move(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn actions_mouse_move(c: Client, port: u16) -> Result<(), error::CmdError> {
     // Set window size to avoid moving the cursor out-of-bounds during actions.
     c.set_window_rect(0, 0, 800, 800).await?;
 
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 
-    let mut elem = c.find(Locator::Id("button-alert")).await?;
+    let elem = c.find(Locator::Id("button-alert")).await?;
     let rect = elem.rectangle().await?;
     let elem_center_x = rect.0 + (rect.2 / 2.0);
     let elem_center_y = rect.1 + (rect.3 / 2.0);
@@ -133,7 +133,7 @@ async fn actions_mouse_move(mut c: Client, port: u16) -> Result<(), error::CmdEr
     Ok(())
 }
 
-async fn actions_release(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn actions_release(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 
@@ -142,7 +142,7 @@ async fn actions_release(mut c: Client, port: u16) -> Result<(), error::CmdError
     elem.click().await?;
 
     // Add initial text.
-    let mut elem = c.find(Locator::Id("text-input")).await?;
+    let elem = c.find(Locator::Id("text-input")).await?;
     assert_eq!(elem.prop("value").await?.unwrap(), "");
 
     // Press CONTROL key down and hold it.

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 mod common;
 
-async fn alert_accept(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn alert_accept(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     c.find(Locator::Id("button-alert")).await?.click().await?;
@@ -31,7 +31,7 @@ async fn alert_accept(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn alert_dismiss(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn alert_dismiss(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     c.find(Locator::Id("button-alert")).await?.click().await?;
@@ -57,7 +57,7 @@ async fn alert_dismiss(mut c: Client, port: u16) -> Result<(), error::CmdError> 
     Ok(())
 }
 
-async fn alert_text(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn alert_text(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     c.find(Locator::Id("button-prompt")).await?.click().await?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -130,7 +130,7 @@ macro_rules! tester_inner {
                 .enable_all()
                 .build()
                 .unwrap();
-            let mut c = rt.block_on(c).expect("failed to construct test client");
+            let c = rt.block_on(c).expect("failed to construct test client");
             *sid.lock().unwrap() = rt.block_on(c.session_id()).unwrap();
             // make sure we close, even if an assertion fails
             let x = rt.block_on(async move {

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -6,15 +6,15 @@ use serial_test::serial;
 
 mod common;
 
-async fn element_is(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_is(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     assert!(elem.is_enabled().await?);
     assert!(elem.is_displayed().await?);
     assert!(!elem.is_selected().await?);
     elem.click().await?;
-    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     assert!(elem.is_selected().await?);
 
     assert!(
@@ -32,47 +32,51 @@ async fn element_is(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn element_attr(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_attr(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     assert_eq!(elem.attr("id").await?.unwrap(), "checkbox-option-1");
     assert!(elem.attr("invalid-attribute").await?.is_none());
     Ok(())
 }
 
-async fn element_prop(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_prop(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     assert_eq!(elem.prop("id").await?.unwrap(), "checkbox-option-1");
     assert_eq!(elem.prop("checked").await?.unwrap(), "false");
     assert!(elem.attr("invalid-property").await?.is_none());
     Ok(())
 }
 
-async fn element_css_value(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_css_value(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("checkbox-hidden")).await?;
+    let elem = c.find(Locator::Id("checkbox-hidden")).await?;
     assert_eq!(elem.css_value("display").await?, "none");
     assert_eq!(elem.css_value("invalid-css-value").await?, "");
     Ok(())
 }
 
-async fn element_tag_name(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_tag_name(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("checkbox-option-1")).await?;
+    let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     let tag_name = elem.tag_name().await?;
-    assert!(tag_name.eq_ignore_ascii_case("input"), "{} != input", tag_name);
+    assert!(
+        tag_name.eq_ignore_ascii_case("input"),
+        "{} != input",
+        tag_name
+    );
     Ok(())
 }
 
-async fn element_rect(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_rect(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("button-alert")).await?;
+    let elem = c.find(Locator::Id("button-alert")).await?;
     let rect = elem.rectangle().await?;
     // Rather than try to verify the exact position and size of the element,
     // let's just verify that the returned values deserialized ok and
@@ -88,10 +92,10 @@ async fn element_rect(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn element_send_keys(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn element_send_keys(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
-    let mut elem = c.find(Locator::Id("text-input")).await?;
+    let elem = c.find(Locator::Id("text-input")).await?;
     assert_eq!(elem.prop("value").await?.unwrap(), "");
     elem.send_keys("fantoccini").await?;
     assert_eq!(elem.prop("value").await?.unwrap(), "fantoccini");

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 mod common;
 
-async fn goto(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn goto(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     let current_url = c.current_url().await?;
@@ -15,7 +15,7 @@ async fn goto(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn find_and_click_link(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn find_and_click_link(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     c.find(Locator::Css("#other_page_id"))
@@ -30,18 +30,18 @@ async fn find_and_click_link(mut c: Client, port: u16) -> Result<(), error::CmdE
     c.close().await
 }
 
-async fn get_active_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn get_active_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     c.find(Locator::Css("#select1")).await?.click().await?;
 
-    let mut active = c.active_element().await?;
+    let active = c.active_element().await?;
     assert_eq!(active.attr("id").await?, Some(String::from("select1")));
 
     c.close().await
 }
 
-async fn serialize_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn serialize_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     let elem = c.find(Locator::Css("#other_page_id")).await?;
@@ -65,7 +65,7 @@ async fn serialize_element(mut c: Client, port: u16) -> Result<(), error::CmdErr
     c.close().await
 }
 
-async fn iframe_switch(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn iframe_switch(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     // Go to the page that holds the iframe
@@ -91,20 +91,20 @@ async fn iframe_switch(mut c: Client, port: u16) -> Result<(), error::CmdError> 
         .expect_err("Should not be able to access content in the root context");
 
     // switch back to the root context and access content there.
-    let mut c = c.enter_parent_frame().await?;
+    c.enter_parent_frame().await?;
     c.find(Locator::Id("root_button")).await?;
 
     c.close().await
 }
 
-async fn new_window(mut c: Client) -> Result<(), error::CmdError> {
+async fn new_window(c: Client) -> Result<(), error::CmdError> {
     c.new_window(false).await?;
     let windows = c.windows().await?;
     assert_eq!(windows.len(), 2);
     c.close().await
 }
 
-async fn new_window_switch(mut c: Client) -> Result<(), error::CmdError> {
+async fn new_window_switch(c: Client) -> Result<(), error::CmdError> {
     let window_1 = c.window().await?;
     c.new_window(false).await?;
     let window_2 = c.window().await?;
@@ -131,7 +131,7 @@ async fn new_window_switch(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn new_tab_switch(mut c: Client) -> Result<(), error::CmdError> {
+async fn new_tab_switch(c: Client) -> Result<(), error::CmdError> {
     let window_1 = c.window().await?;
     c.new_window(true).await?;
     let window_2 = c.window().await?;
@@ -158,7 +158,7 @@ async fn new_tab_switch(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn close_window(mut c: Client) -> Result<(), error::CmdError> {
+async fn close_window(c: Client) -> Result<(), error::CmdError> {
     let window_1 = c.window().await?;
     c.new_window(true).await?;
     let window_2 = c.window().await?;
@@ -188,7 +188,7 @@ async fn close_window(mut c: Client) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn close_window_twice_errors(mut c: Client) -> Result<(), error::CmdError> {
+async fn close_window_twice_errors(c: Client) -> Result<(), error::CmdError> {
     c.close_window().await?;
     c.close_window()
         .await
@@ -196,11 +196,11 @@ async fn close_window_twice_errors(mut c: Client) -> Result<(), error::CmdError>
     Ok(())
 }
 
-async fn set_by_name_textarea(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn set_by_name_textarea(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
 
-    let mut form = c.form(Locator::Css("form")).await?;
+    let form = c.form(Locator::Css("form")).await?;
     form.set_by_name("some_textarea", "a value!").await?;
 
     let value = c
@@ -215,7 +215,7 @@ async fn set_by_name_textarea(mut c: Client, port: u16) -> Result<(), error::Cmd
     Ok(())
 }
 
-async fn stale_element(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn stale_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
     let elem = c.find(Locator::Css("#other_page_id")).await?;
@@ -234,11 +234,11 @@ async fn stale_element(mut c: Client, port: u16) -> Result<(), error::CmdError> 
     }
 }
 
-async fn select_by_index(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn select_by_index(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
 
-    let mut select_element = c.find(Locator::Css("#select1")).await?;
+    let select_element = c.find(Locator::Css("#select1")).await?;
 
     // Get first display text
     let initial_text = select_element.prop("value").await?;
@@ -260,7 +260,7 @@ async fn select_by_index(mut c: Client, port: u16) -> Result<(), error::CmdError
     assert_eq!(Some("Select2-Option1".into()), select2_text);
 
     // Show off that it selects only options and skip any other elements
-    let mut select_element = c.find(Locator::Css("#select2")).await?;
+    let select_element = c.find(Locator::Css("#select2")).await?;
     select_element.clone().select_by_index(1).await?;
     let text = select_element.prop("value").await?;
     assert_eq!(Some("Select2-Option2".into()), text);
@@ -268,11 +268,11 @@ async fn select_by_index(mut c: Client, port: u16) -> Result<(), error::CmdError
     Ok(())
 }
 
-async fn select_by_label(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn select_by_label(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
 
-    let mut select_element = c.find(Locator::Css("#select1")).await?;
+    let select_element = c.find(Locator::Css("#select1")).await?;
 
     // Get first display text
     let initial_text = select_element.prop("value").await?;
@@ -299,11 +299,11 @@ async fn select_by_label(mut c: Client, port: u16) -> Result<(), error::CmdError
     Ok(())
 }
 
-async fn select_by(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn select_by(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
 
-    let mut select_element = c.find(Locator::Css("#select3")).await?;
+    let select_element = c.find(Locator::Css("#select3")).await?;
 
     // Get first display text
     let initial_text = select_element.prop("value").await?;
@@ -322,7 +322,7 @@ async fn select_by(mut c: Client, port: u16) -> Result<(), error::CmdError> {
     Ok(())
 }
 
-async fn resolve_execute_async_value(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn resolve_execute_async_value(c: Client, port: u16) -> Result<(), error::CmdError> {
     let url = sample_page_url(port);
     c.goto(&url).await?;
 
@@ -348,7 +348,7 @@ async fn resolve_execute_async_value(mut c: Client, port: u16) -> Result<(), err
     Ok(())
 }
 
-async fn back_and_forward(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn back_and_forward(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
 
@@ -367,28 +367,28 @@ async fn back_and_forward(mut c: Client, port: u16) -> Result<(), error::CmdErro
     Ok(())
 }
 
-async fn status_firefox(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+async fn status_firefox(c: Client, _: u16) -> Result<(), error::CmdError> {
     // Geckodriver only supports a single session, and since we're already in a
     // session, it should return `false` here.
     assert!(!c.status().await?.ready);
     Ok(())
 }
 
-async fn status_chrome(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+async fn status_chrome(c: Client, _: u16) -> Result<(), error::CmdError> {
     // Chromedriver supports multiple sessions, so it should always return
     // `true` here.
     assert!(c.status().await?.ready);
     Ok(())
 }
 
-async fn page_title(mut c: Client, port: u16) -> Result<(), error::CmdError> {
+async fn page_title(c: Client, port: u16) -> Result<(), error::CmdError> {
     let sample_url = sample_page_url(port);
     c.goto(&sample_url).await?;
     assert_eq!(c.title().await?, "Sample Page");
     Ok(())
 }
 
-async fn timeouts(mut c: Client, _: u16) -> Result<(), error::CmdError> {
+async fn timeouts(c: Client, _: u16) -> Result<(), error::CmdError> {
     let new_timeouts = TimeoutConfiguration::new(
         Some(Duration::from_secs(60)),
         Some(Duration::from_secs(60)),

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -10,10 +10,10 @@ use url::Url;
 
 mod common;
 
-async fn works_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn works_inner(c: Client) -> Result<(), error::CmdError> {
     // go to the Wikipedia page for Foobar
     c.goto("https://en.wikipedia.org/wiki/Foobar").await?;
-    let mut e = c.find(Locator::Id("History_and_etymology")).await?;
+    let e = c.find(Locator::Id("History_and_etymology")).await?;
     let text = e.text().await?;
     assert_eq!(text, "History and etymology");
     let url = c.current_url().await?;
@@ -31,12 +31,12 @@ async fn works_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn clicks_inner_by_locator(mut c: Client) -> Result<(), error::CmdError> {
+async fn clicks_inner_by_locator(c: Client) -> Result<(), error::CmdError> {
     // go to the Wikipedia frontpage this time
     c.goto("https://www.wikipedia.org/").await?;
 
     // find, fill out, and submit the search form
-    let mut f = c.form(Locator::Css("#search-form")).await?;
+    let f = c.form(Locator::Css("#search-form")).await?;
     let f = f
         .set(Locator::Css("input[name='search']"), "foobar")
         .await?;
@@ -49,12 +49,12 @@ async fn clicks_inner_by_locator(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn clicks_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn clicks_inner(c: Client) -> Result<(), error::CmdError> {
     // go to the Wikipedia frontpage this time
     c.goto("https://www.wikipedia.org/").await?;
 
     // find, fill out, and submit the search form
-    let mut f = c.form(Locator::Css("#search-form")).await?;
+    let f = c.form(Locator::Css("#search-form")).await?;
     let f = f.set_by_name("search", "foobar").await?;
     f.submit().await?;
 
@@ -65,12 +65,12 @@ async fn clicks_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn send_keys_and_clear_input_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn send_keys_and_clear_input_inner(c: Client) -> Result<(), error::CmdError> {
     // go to the Wikipedia frontpage this time
     c.goto("https://www.wikipedia.org/").await?;
 
     // find search input element
-    let mut e = c.wait().for_element(Locator::Id("searchInput")).await?;
+    let e = c.wait().for_element(Locator::Id("searchInput")).await?;
     e.send_keys("foobar").await?;
     assert_eq!(
         e.prop("value")
@@ -89,16 +89,16 @@ async fn send_keys_and_clear_input_inner(mut c: Client) -> Result<(), error::Cmd
         ""
     );
 
-    let mut c = e.client();
+    let c = e.client();
     c.close().await
 }
 
-async fn raw_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn raw_inner(c: Client) -> Result<(), error::CmdError> {
     // go back to the frontpage
     c.goto("https://www.wikipedia.org/").await?;
 
     // find the source for the Wikipedia globe
-    let mut img = c.find(Locator::Css("img.central-featured-logo")).await?;
+    let img = c.find(Locator::Css("img.central-featured-logo")).await?;
     let src = img.attr("src").await?.expect("image should have a src");
 
     // now build a raw HTTP client request (which also has all current cookies)
@@ -116,7 +116,7 @@ async fn raw_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn window_size_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn window_size_inner(c: Client) -> Result<(), error::CmdError> {
     c.goto("https://www.wikipedia.org/").await?;
     c.set_window_size(500, 400).await?;
     let (width, height) = c.get_window_size().await?;
@@ -126,7 +126,7 @@ async fn window_size_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn window_position_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn window_position_inner(c: Client) -> Result<(), error::CmdError> {
     c.goto("https://www.wikipedia.org/").await?;
     c.set_window_size(200, 100).await?;
     c.set_window_position(0, 0).await?;
@@ -138,7 +138,7 @@ async fn window_position_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn window_rect_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn window_rect_inner(c: Client) -> Result<(), error::CmdError> {
     c.goto("https://www.wikipedia.org/").await?;
     c.set_window_rect(0, 0, 500, 400).await?;
     let (x, y) = c.get_window_position().await?;
@@ -158,14 +158,14 @@ async fn window_rect_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn finds_all_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn finds_all_inner(c: Client) -> Result<(), error::CmdError> {
     // go to the Wikipedia frontpage this time
     c.goto("https://en.wikipedia.org/").await?;
     let es = c.find_all(Locator::Css("#p-interaction li")).await?;
     let texts = futures_util::future::try_join_all(
         es.into_iter()
             .take(4)
-            .map(|mut e| async move { e.text().await }),
+            .map(|e| async move { e.text().await }),
     )
     .await?;
     assert_eq!(
@@ -181,11 +181,11 @@ async fn finds_all_inner(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn finds_sub_elements(mut c: Client) -> Result<(), error::CmdError> {
+async fn finds_sub_elements(c: Client) -> Result<(), error::CmdError> {
     // Go to the Wikipedia front page
     c.goto("https://en.wikipedia.org/").await?;
     // Get the main sidebar panel
-    let mut panel = c.find(Locator::Css("div#mw-panel")).await?;
+    let panel = c.find(Locator::Css("div#mw-panel")).await?;
     // Get all the ul elements in the sidebar
     let mut portals = panel.find_all(Locator::Css("nav.portal")).await?;
 
@@ -204,7 +204,7 @@ async fn finds_sub_elements(mut c: Client) -> Result<(), error::CmdError> {
 
     for (i, portal) in portals.iter_mut().enumerate() {
         // Each "portal" has an h3 element.
-        let mut portal_title = portal.find(Locator::Css("h3")).await?;
+        let portal_title = portal.find(Locator::Css("h3")).await?;
         let portal_title = portal_title.text().await?;
         assert_eq!(portal_title, portal_titles[i]);
         // And also an <ul>.
@@ -215,14 +215,14 @@ async fn finds_sub_elements(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn persist_inner(mut c: Client) -> Result<(), error::CmdError> {
+async fn persist_inner(c: Client) -> Result<(), error::CmdError> {
     c.goto("https://en.wikipedia.org/").await?;
     c.persist().await?;
 
     c.close().await
 }
 
-async fn simple_wait_test(mut c: Client) -> Result<(), error::CmdError> {
+async fn simple_wait_test(c: Client) -> Result<(), error::CmdError> {
     #[allow(deprecated)]
     c.wait_for(move |_| {
         std::thread::sleep(Duration::from_secs(4));
@@ -233,7 +233,7 @@ async fn simple_wait_test(mut c: Client) -> Result<(), error::CmdError> {
     c.close().await
 }
 
-async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> {
+async fn wait_for_navigation_test(c: Client) -> Result<(), error::CmdError> {
     let mut path = std::env::current_dir().unwrap();
     path.push("tests/redirect_test.html");
 
@@ -260,7 +260,7 @@ async fn wait_for_navigation_test(mut c: Client) -> Result<(), error::CmdError> 
 }
 
 // Verifies that basic cookie handling works
-async fn handle_cookies_test(mut c: Client) -> Result<(), error::CmdError> {
+async fn handle_cookies_test(c: Client) -> Result<(), error::CmdError> {
     c.goto("https://www.wikipedia.org/").await?;
 
     let cookies = c.get_all_cookies().await?;


### PR DESCRIPTION
This is intended firstly as a discussion point w.r.t. issue #153 and also to show how this would look with all of the mutability requirements minimized. 

The one method where I think capturing self might be warranted is `Client::close()`.

Perhaps its sig could be changed to:
```rust
pub async fn close(self) -> Result<Client, error::CmdError> {
```

Obviously all of this is a highly disruptive breaking change with many implications for calling code.