### PR TITLE
Implement `Wheel` actions to support scrolling.

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -271,6 +271,11 @@ impl KeyActions {
             actions: Vec::new(),
         }
     }
+
+    /// Pushes a new action.
+    pub fn push(&mut self, action: KeyAction) {
+        self.actions.push(action);
+    }
 }
 
 impl From<KeyActions> for ActionSequence {
@@ -304,6 +309,16 @@ impl MouseActions {
             id,
             actions: Vec::new(),
         }
+    }
+
+    /// Pushes a new action.
+    pub fn push(&mut self, action: PointerAction) {
+        self.actions.push(action);
+    }
+
+    /// Returns the number of actions currently in this sequence.
+    pub fn len(&self) -> usize {
+        self.actions.len()
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -717,11 +717,13 @@ impl Client {
         &self,
         actions: impl Into<Actions>,
     ) -> Result<(), error::CmdError> {
-        let params = webdriver::command::ActionsParameters {
+        let params = crate::wd::extensions::ActionsParameters {
             actions: actions.into().sequences.into_iter().map(|x| x.0).collect(),
         };
 
-        self.issue(WebDriverCommand::PerformActions(params)).await?;
+        let cmd = crate::wd::extensions::ExtendedActionCommand { actions: params };
+
+        self.issue_cmd(cmd).await?;
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,6 +157,12 @@ impl CmdError {
         matches!(self, CmdError::NoSuchElement(..))
     }
 
+    /// Returns true if this error indicates that a used element has gone stale since it was
+    /// selected.
+    pub fn is_stale_element(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == webdriver::ErrorStatus::StaleElementReference)
+    }
+
     pub(crate) fn from_webdriver_error(e: webdriver::WebDriverError) -> Self {
         match e {
             webdriver::WebDriverError {


### PR DESCRIPTION
The new webdriver standard includes `wheel` actions for simulating scroll wheels. https://www.w3.org/TR/webdriver/#wheel-actions

The upstream `webdriver` crate hasn't implemented it, but I worked around it here by implementing a new `WebDriverCompatibleCommand` that makes use of the new wheel implementation and the existing webdriver structures. This required a minimal amount of re-implementing structs from webdriver.

I'm not sure how universally the wheel APIs are implemented, but this is working just fine for me in `chromedriver 99.0.4844.51`.

This PR un-apologetically includes some other new methods that I needed around actions and the `Error` type. I can remove them if that is a blocker.