### PR TITLE
Update webdriver to 0.46

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ native-tls = ["hyper-tls"]
 rustls-tls = ["hyper-rustls"]
 
 [dependencies]
-webdriver = { version = "0.45", default-features = false }
+webdriver = { version = "0.46", default-features = false }
 url = "2.2.2"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,6 @@ mime = "0.3.9"
 http = "0.2"
 time = "0.3"
 
-# to make -Zminimal-versions happy
-# remove gcc and winapi 0.0.1 from build tree
-# only here because webdriver depends on time 0.1 and cookie 0.12 (which also does)
-_time01 = { version = "0.1.34", package = "time" }
-
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 hyper = { version = "0.14", features = ["server", "tcp"] }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -175,10 +175,16 @@ impl PointerAction {
                 }),
             ),
             PointerAction::Down { button } => WDActions::PointerActionItem::Pointer(
-                WDActions::PointerAction::Down(WDActions::PointerDownAction { button }),
+                WDActions::PointerAction::Down(WDActions::PointerDownAction {
+                    button,
+                    ..Default::default()
+                }),
             ),
             PointerAction::Up { button } => WDActions::PointerActionItem::Pointer(
-                WDActions::PointerAction::Up(WDActions::PointerUpAction { button }),
+                WDActions::PointerAction::Up(WDActions::PointerUpAction {
+                    button,
+                    ..Default::default()
+                }),
             ),
             PointerAction::MoveBy { duration, x, y } => WDActions::PointerActionItem::Pointer(
                 WDActions::PointerAction::Move(WDActions::PointerMoveAction {
@@ -186,6 +192,7 @@ impl PointerAction {
                     origin: WDActions::PointerOrigin::Pointer,
                     x: Some(x),
                     y: Some(y),
+                    ..Default::default()
                 }),
             ),
             PointerAction::MoveTo { duration, x, y } => WDActions::PointerActionItem::Pointer(
@@ -194,6 +201,7 @@ impl PointerAction {
                     origin: WDActions::PointerOrigin::Viewport,
                     x: Some(x),
                     y: Some(y),
+                    ..Default::default()
                 }),
             ),
             PointerAction::MoveToElement {
@@ -207,6 +215,7 @@ impl PointerAction {
                     origin: WDActions::PointerOrigin::Element(element.element),
                     x: Some(x),
                     y: Some(y),
+                    ..Default::default()
                 },
             )),
             PointerAction::Cancel => {

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -140,12 +140,10 @@ impl Client {
         let resp = self.issue(WebDriverCommand::GetCookies).await?;
 
         let webdriver_cookies: Vec<WebDriverCookie> = serde_json::from_value(resp)?;
-        let cookies: Result<Vec<Cookie<'static>>, error::CmdError> = webdriver_cookies
+        webdriver_cookies
             .into_iter()
             .map(|raw_cookie| raw_cookie.try_into())
-            .collect();
-
-        Ok(cookies?)
+            .collect()
     }
 
     /// Get a single named cookie associated with the current document.
@@ -157,7 +155,7 @@ impl Client {
             .issue(WebDriverCommand::GetNamedCookie(name.to_string()))
             .await?;
         let webdriver_cookie: WebDriverCookie = serde_json::from_value(resp)?;
-        Ok(webdriver_cookie.try_into()?)
+        webdriver_cookie.try_into()
     }
 
     /// Add the specified cookie.


### PR DESCRIPTION
This PR updates `webdriver` to the latest version and makes the required adjustments for it to compile. I have not tested this locally since I'm unable to get `geckodriver` working, so I'm relying on CI to catch if some of these fields need filled out more.

Supersedes #173 