### PR TITLE
Add `charset=utf-8` to session `Content-Type` header

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -740,8 +740,12 @@ where
             );
         }
 
+        let json_mime: mime::Mime = "application/json; charset=utf-8"
+            .parse::<mime::Mime>()
+            .unwrap_or(mime::APPLICATION_JSON);
+
         let req = if let Some(body) = body.take() {
-            req = req.header(hyper::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref());
+            req = req.header(hyper::header::CONTENT_TYPE, json_mime.as_ref());
             req = req.header(hyper::header::CONTENT_LENGTH, body.len());
             self.client.request(req.body(body.into()).unwrap())
         } else {


### PR DESCRIPTION
Fixes: #180
BrowserStack (selenium v >=4) requires the charset to be set due to some
undisclosed security vulnerability, despite technically being implied by
the JSON spec.

Adding `charset=utf-8` should not have any backward compatibility issues
with current users.
