### PR TITLE
Add ErrorStatus enum and remove webdriver::error::WebDriverError

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -431,7 +431,7 @@ impl Element {
             Json::Null => {
                 let e = error::WebDriver::new(
                     error::ErrorStatus::InvalidArgument,
-                    "cannot follow element without href attribute".into(),
+                    "cannot follow element without href attribute",
                 );
                 return Err(error::CmdError::Standard(e));
             }
@@ -447,7 +447,6 @@ impl Element {
     /// Find and click an `<option>` child element by a locator.
     ///
     /// This method clicks the first `<option>` element that is found.
-    /// If the element wasn't found, [`CmdError::NoSuchElement`](error::CmdError::NoSuchElement) will be issued.
     pub async fn select_by(&self, locator: Locator<'_>) -> Result<(), error::CmdError> {
         self.find(locator).await?.click().await
     }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -431,7 +431,7 @@ impl Element {
             Json::Null => {
                 let e = error::WebDriver::new(
                     error::ErrorStatus::InvalidArgument,
-                    "cannot follow element without href attribute".to_string(),
+                    "cannot follow element without href attribute".into(),
                 );
                 return Err(error::CmdError::Standard(e));
             }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -8,7 +8,6 @@ use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use webdriver::command::WebDriverCommand;
 use webdriver::common::FrameId;
-use webdriver::error::WebDriverError;
 
 /// Web element reference.
 ///
@@ -430,13 +429,11 @@ impl Element {
         let href = match href {
             Json::String(v) => v,
             Json::Null => {
-                let e = WebDriverError::new(
-                    webdriver::error::ErrorStatus::InvalidArgument,
-                    "cannot follow element without href attribute",
+                let e = error::WebDriver::new(
+                    error::ErrorStatus::InvalidArgument,
+                    "cannot follow element without href attribute".to_string(),
                 );
-                return Err(error::CmdError::Standard(
-                    error::WebDriver::from_upstream_error(e),
-                ));
+                return Err(error::CmdError::Standard(e));
             }
             v => return Err(error::CmdError::NotW3C(v)),
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,24 +113,154 @@ pub enum CmdError {
 }
 
 impl CmdError {
-    /// Returns true if this error indicates that a matching element was not found.
-    ///
-    /// Equivalent to
-    /// ```no_run
-    /// # use fantoccini::error::{CmdError, ErrorStatus};
-    /// # let e = CmdError::NotJson(String::new());
-    /// let is_miss = if let CmdError::Standard(w) = e {
-    ///     matches!(w.error, ErrorStatus::NoSuchElement)
-    /// } else {
-    ///     false
-    /// };
-    /// ```
-    pub fn is_miss(&self) -> bool {
-        if let CmdError::Standard(w) = self {
-            matches!(w.error, ErrorStatus::NoSuchElement)
-        } else {
-            false
-        }
+    /// Return true if this error matches [`ErrorStatus::DetachedShadowRoot`].
+    pub fn is_detached_shadow_root(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::DetachedShadowRoot)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::ElementNotInteractable`].
+    pub fn is_element_not_interactable(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ElementNotInteractable)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::ElementNotSelectable`].
+    pub fn is_element_not_selectable(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ElementNotSelectable)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InsecureCertificate`].
+    pub fn is_insecure_certificate(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InsecureCertificate)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidArgument`].
+    pub fn is_invalid_argument(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidArgument)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidCookieDomain`].
+    pub fn is_invalid_cookie_domain(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidCookieDomain)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidCoordinates`].
+    pub fn is_invalid_coordinates(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidCoordinates)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidElementState`].
+    pub fn is_invalid_element_state(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidElementState)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidSelector`].
+    pub fn is_invalid_selector(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidSelector)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::InvalidSessionId`].
+    pub fn is_invalid_session_id(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidSessionId)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::JavascriptError`].
+    pub fn is_javascript_error(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::JavascriptError)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::MoveTargetOutOfBounds`].
+    pub fn is_move_target_out_of_bounds(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::MoveTargetOutOfBounds)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchAlert`].
+    pub fn is_no_such_alert(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchAlert)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchCookie`].
+    pub fn is_no_such_cookie(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchCookie)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchElement`].
+    pub fn is_no_such_element(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchElement)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchFrame`].
+    pub fn is_no_such_frame(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchFrame)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchShadowRoot`].
+    pub fn is_no_such_shadow_root(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchShadowRoot)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::NoSuchWindow`].
+    pub fn is_no_such_window(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchWindow)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::ScriptTimeout`].
+    pub fn is_script_timeout(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ScriptTimeout)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::SessionNotCreated`].
+    pub fn is_session_not_created(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::SessionNotCreated)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::StaleElementReference`].
+    pub fn is_stale_element_reference(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::StaleElementReference)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::Timeout`].
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::Timeout)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnableToCaptureScreen`].
+    pub fn is_unable_to_capture_screen(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnableToCaptureScreen)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnableToSetCookie`].
+    pub fn is_unable_to_set_cookie(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnableToSetCookie)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnexpectedAlertOpen`].
+    pub fn is_unexpected_alert_open(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnexpectedAlertOpen)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnknownCommand`].
+    pub fn is_unknown_command(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownCommand)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnknownError`].
+    pub fn is_unknown_error(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownError)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnknownMethod`].
+    pub fn is_unknown_method(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownMethod)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnknownPath`].
+    pub fn is_unknown_path(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownPath)
+    }
+
+    /// Return true if this error matches [`ErrorStatus::UnsupportedOperation`].
+    pub fn is_unsupported_operation(&self) -> bool {
+        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnsupportedOperation)
     }
 
     pub(crate) fn from_webdriver_error(e: WebDriver) -> Self {
@@ -243,6 +373,7 @@ impl From<InvalidWindowHandle> for CmdError {
 pub enum ErrorStatus {
     /// The [element]'s [ShadowRoot] is not attached to the active document,
     /// or the reference is stale
+    ///
     /// [element]: https://www.w3.org/TR/webdriver2/#dfn-elements
     /// [ShadowRoot]: https://www.w3.org/TR/webdriver2/#dfn-shadow-roots
     DetachedShadowRoot,
@@ -384,6 +515,43 @@ pub enum ErrorStatus {
 }
 
 impl ErrorStatus {
+    /// Get the error string associated with this `ErrorStatus`.
+    pub fn description(&self) -> &'static str {
+        use self::ErrorStatus::*;
+        match self {
+            DetachedShadowRoot => "detached shadow root",
+            ElementClickIntercepted => "element click intercepted",
+            ElementNotInteractable => "element not interactable",
+            ElementNotSelectable => "element not selectable",
+            InsecureCertificate => "insecure certificate",
+            InvalidArgument => "invalid argument",
+            InvalidCookieDomain => "invalid cookie domain",
+            InvalidCoordinates => "invalid coordinates",
+            InvalidElementState => "invalid element state",
+            InvalidSelector => "invalid selector",
+            InvalidSessionId => "invalid session id",
+            JavascriptError => "javascript error",
+            MoveTargetOutOfBounds => "move target out of bounds",
+            NoSuchAlert => "no such alert",
+            NoSuchCookie => "no such cookie",
+            NoSuchElement => "no such element",
+            NoSuchFrame => "no such frame",
+            NoSuchShadowRoot => "no such shadow root",
+            NoSuchWindow => "no such window",
+            ScriptTimeout => "script timeout",
+            SessionNotCreated => "session not created",
+            StaleElementReference => "stale element reference",
+            Timeout => "timeout",
+            UnableToCaptureScreen => "unable to capture screen",
+            UnableToSetCookie => "unable to set cookie",
+            UnexpectedAlertOpen => "unexpected alert open",
+            UnknownCommand | UnknownError => "unknown error",
+            UnknownMethod => "unknown method",
+            UnknownPath => "unknown command",
+            UnsupportedOperation => "unsupported operation",
+        }
+    }
+
     /// Returns the correct HTTP status code associated with the error type.
     pub fn http_status(&self) -> StatusCode {
         use self::ErrorStatus::*;
@@ -425,40 +593,7 @@ impl ErrorStatus {
 
 impl fmt::Display for ErrorStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use self::ErrorStatus::*;
-        let error_message = match self {
-            DetachedShadowRoot => "detached shadow root",
-            ElementClickIntercepted => "element click intercepted",
-            ElementNotInteractable => "element not interactable",
-            ElementNotSelectable => "element not selectable",
-            InsecureCertificate => "insecure certificate",
-            InvalidArgument => "invalid argument",
-            InvalidCookieDomain => "invalid cookie domain",
-            InvalidCoordinates => "invalid coordinates",
-            InvalidElementState => "invalid element state",
-            InvalidSelector => "invalid selector",
-            InvalidSessionId => "invalid session id",
-            JavascriptError => "javascript error",
-            MoveTargetOutOfBounds => "move target out of bounds",
-            NoSuchAlert => "no such alert",
-            NoSuchCookie => "no such cookie",
-            NoSuchElement => "no such element",
-            NoSuchFrame => "no such frame",
-            NoSuchShadowRoot => "no such shadow root",
-            NoSuchWindow => "no such window",
-            ScriptTimeout => "script timeout",
-            SessionNotCreated => "session not created",
-            StaleElementReference => "stale element reference",
-            Timeout => "timeout",
-            UnableToCaptureScreen => "unable to capture screen",
-            UnableToSetCookie => "unable to set cookie",
-            UnexpectedAlertOpen => "unexpected alert open",
-            UnknownCommand | UnknownError => "unknown error",
-            UnknownMethod => "unknown method",
-            UnknownPath => "unknown command",
-            UnsupportedOperation => "unsupported operation",
-        };
-        write!(f, "{}", error_message)
+        write!(f, "{}", self.description())
     }
 }
 
@@ -469,7 +604,7 @@ impl Serialize for ErrorStatus {
     where
         S: Serializer,
     {
-        self.to_string().serialize(serializer)
+        self.description().serialize(serializer)
     }
 }
 
@@ -560,10 +695,10 @@ impl Error for WebDriver {}
 
 impl WebDriver {
     /// Create a new WebDriver error struct.
-    pub fn new(error: ErrorStatus, message: Cow<'static, str>) -> Self {
+    pub fn new(error: ErrorStatus, message: impl Into<Cow<'static, str>>) -> Self {
         Self {
             error,
-            message,
+            message: message.into(),
             stacktrace: String::new(),
             data: None,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,155 +112,50 @@ pub enum CmdError {
     WaitTimeout,
 }
 
+macro_rules! is_helper {
+    ($($variant:ident => $name:ident$(,)?),*) => {
+        $(
+            /// Return true if this error matches
+            #[doc = concat!("[`ErrorStatus::", stringify!($variant), "`].")]
+            pub fn $name(&self) -> bool {
+                matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::$variant)
+            }
+        )*
+    }
+}
+
 impl CmdError {
-    /// Return true if this error matches [`ErrorStatus::DetachedShadowRoot`].
-    pub fn is_detached_shadow_root(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::DetachedShadowRoot)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::ElementNotInteractable`].
-    pub fn is_element_not_interactable(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ElementNotInteractable)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::ElementNotSelectable`].
-    pub fn is_element_not_selectable(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ElementNotSelectable)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InsecureCertificate`].
-    pub fn is_insecure_certificate(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InsecureCertificate)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidArgument`].
-    pub fn is_invalid_argument(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidArgument)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidCookieDomain`].
-    pub fn is_invalid_cookie_domain(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidCookieDomain)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidCoordinates`].
-    pub fn is_invalid_coordinates(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidCoordinates)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidElementState`].
-    pub fn is_invalid_element_state(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidElementState)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidSelector`].
-    pub fn is_invalid_selector(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidSelector)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::InvalidSessionId`].
-    pub fn is_invalid_session_id(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::InvalidSessionId)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::JavascriptError`].
-    pub fn is_javascript_error(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::JavascriptError)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::MoveTargetOutOfBounds`].
-    pub fn is_move_target_out_of_bounds(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::MoveTargetOutOfBounds)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchAlert`].
-    pub fn is_no_such_alert(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchAlert)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchCookie`].
-    pub fn is_no_such_cookie(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchCookie)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchElement`].
-    pub fn is_no_such_element(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchElement)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchFrame`].
-    pub fn is_no_such_frame(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchFrame)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchShadowRoot`].
-    pub fn is_no_such_shadow_root(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchShadowRoot)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::NoSuchWindow`].
-    pub fn is_no_such_window(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::NoSuchWindow)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::ScriptTimeout`].
-    pub fn is_script_timeout(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::ScriptTimeout)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::SessionNotCreated`].
-    pub fn is_session_not_created(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::SessionNotCreated)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::StaleElementReference`].
-    pub fn is_stale_element_reference(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::StaleElementReference)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::Timeout`].
-    pub fn is_timeout(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::Timeout)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnableToCaptureScreen`].
-    pub fn is_unable_to_capture_screen(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnableToCaptureScreen)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnableToSetCookie`].
-    pub fn is_unable_to_set_cookie(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnableToSetCookie)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnexpectedAlertOpen`].
-    pub fn is_unexpected_alert_open(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnexpectedAlertOpen)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnknownCommand`].
-    pub fn is_unknown_command(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownCommand)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnknownError`].
-    pub fn is_unknown_error(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownError)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnknownMethod`].
-    pub fn is_unknown_method(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownMethod)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnknownPath`].
-    pub fn is_unknown_path(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnknownPath)
-    }
-
-    /// Return true if this error matches [`ErrorStatus::UnsupportedOperation`].
-    pub fn is_unsupported_operation(&self) -> bool {
-        matches!(self, CmdError::Standard(w) if w.error == ErrorStatus::UnsupportedOperation)
+    is_helper! {
+        DetachedShadowRoot => is_detached_shadow_root,
+        ElementNotInteractable => is_element_not_interactable,
+        ElementNotSelectable => is_element_not_selectable,
+        InsecureCertificate => is_insecure_certificate,
+        InvalidArgument => is_invalid_argument,
+        InvalidCookieDomain => is_invalid_cookie_domain,
+        InvalidCoordinates => is_invalid_coordinates,
+        InvalidElementState => is_invalid_element_state,
+        InvalidSelector => is_invalid_selector,
+        InvalidSessionId => is_invalid_session_id,
+        JavascriptError => is_javascript_error,
+        MoveTargetOutOfBounds => is_move_target_out_of_bounds,
+        NoSuchAlert => is_no_such_alert,
+        NoSuchCookie => is_no_such_cookie,
+        NoSuchElement => is_no_such_element,
+        NoSuchFrame => is_no_such_frame,
+        NoSuchShadowRoot => is_no_such_shadow_root,
+        NoSuchWindow => is_no_such_window,
+        ScriptTimeout => is_script_timeout,
+        SessionNotCreated => is_session_not_created,
+        StaleElementReference => is_stale_element_reference,
+        Timeout => is_timeout,
+        UnableToCaptureScreen => is_unable_to_capture_screen,
+        UnableToSetCookie => is_unable_to_set_cookie,
+        UnexpectedAlertOpen => is_unexpected_alert_open,
+        UnknownCommand => is_unknown_command,
+        UnknownError => is_unknown_error,
+        UnknownMethod => is_unknown_method,
+        UnknownPath => is_unknown_path,
+        UnsupportedOperation => is_unsupported_operation
     }
 
     pub(crate) fn from_webdriver_error(e: WebDriver) -> Self {
@@ -515,43 +410,6 @@ pub enum ErrorStatus {
 }
 
 impl ErrorStatus {
-    /// Get the error string associated with this `ErrorStatus`.
-    pub fn description(&self) -> &'static str {
-        use self::ErrorStatus::*;
-        match self {
-            DetachedShadowRoot => "detached shadow root",
-            ElementClickIntercepted => "element click intercepted",
-            ElementNotInteractable => "element not interactable",
-            ElementNotSelectable => "element not selectable",
-            InsecureCertificate => "insecure certificate",
-            InvalidArgument => "invalid argument",
-            InvalidCookieDomain => "invalid cookie domain",
-            InvalidCoordinates => "invalid coordinates",
-            InvalidElementState => "invalid element state",
-            InvalidSelector => "invalid selector",
-            InvalidSessionId => "invalid session id",
-            JavascriptError => "javascript error",
-            MoveTargetOutOfBounds => "move target out of bounds",
-            NoSuchAlert => "no such alert",
-            NoSuchCookie => "no such cookie",
-            NoSuchElement => "no such element",
-            NoSuchFrame => "no such frame",
-            NoSuchShadowRoot => "no such shadow root",
-            NoSuchWindow => "no such window",
-            ScriptTimeout => "script timeout",
-            SessionNotCreated => "session not created",
-            StaleElementReference => "stale element reference",
-            Timeout => "timeout",
-            UnableToCaptureScreen => "unable to capture screen",
-            UnableToSetCookie => "unable to set cookie",
-            UnexpectedAlertOpen => "unexpected alert open",
-            UnknownCommand | UnknownError => "unknown error",
-            UnknownMethod => "unknown method",
-            UnknownPath => "unknown command",
-            UnsupportedOperation => "unsupported operation",
-        }
-    }
-
     /// Returns the correct HTTP status code associated with the error type.
     pub fn http_status(&self) -> StatusCode {
         use self::ErrorStatus::*;
@@ -608,44 +466,75 @@ impl Serialize for ErrorStatus {
     }
 }
 
-impl FromStr for ErrorStatus {
-    type Err = CmdError;
+// This macro implements conversions between the error string literal and the
+// corresponding ErrorStatus variant.
+//
+// In cases where multiple different string literals map to the same ErrorStatus
+// variant, only the first string literal will be returned when converting from
+// ErrorStatus to a static string.
+macro_rules! define_error_strings {
+    ($($variant:ident => $error_str:literal $(| $error_str_aliases:literal)*$(,)?),*) => {
+        impl ErrorStatus {
+            /// Get the error string associated with this `ErrorStatus`.
+            pub fn description(&self) -> &'static str {
+                use self::ErrorStatus::*;
+                match self {
+                    $(
+                        $variant => $error_str,
+                    )*
+                }
+            }
+        }
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use self::ErrorStatus::*;
-        let status: ErrorStatus = match s {
-            "detached shadow root" => DetachedShadowRoot,
-            "element click intercepted" => ElementClickIntercepted,
-            "element not interactable" | "element not visible" => ElementNotInteractable,
-            "element not selectable" => ElementNotSelectable,
-            "insecure certificate" => InsecureCertificate,
-            "invalid argument" => InvalidArgument,
-            "invalid cookie domain" => InvalidCookieDomain,
-            "invalid coordinates" | "invalid element coordinates" => InvalidCoordinates,
-            "invalid element state" => InvalidElementState,
-            "invalid selector" => InvalidSelector,
-            "invalid session id" => InvalidSessionId,
-            "javascript error" => JavascriptError,
-            "move target out of bounds" => MoveTargetOutOfBounds,
-            "no such alert" => NoSuchAlert,
-            "no such element" => NoSuchElement,
-            "no such frame" => NoSuchFrame,
-            "no such shadow root" => NoSuchShadowRoot,
-            "no such window" => NoSuchWindow,
-            "script timeout" => ScriptTimeout,
-            "session not created" => SessionNotCreated,
-            "stale element reference" => StaleElementReference,
-            "timeout" => Timeout,
-            "unable to capture screen" => UnableToCaptureScreen,
-            "unable to set cookie" => UnableToSetCookie,
-            "unexpected alert open" => UnexpectedAlertOpen,
-            "unknown command" => UnknownCommand,
-            "unknown error" => UnknownError,
-            "unsupported operation" => UnsupportedOperation,
-            _ => return Err(CmdError::NotW3C(serde_json::Value::String(s.to_string()))),
-        };
-        Ok(status)
+        impl FromStr for ErrorStatus {
+            type Err = CmdError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                use self::ErrorStatus::*;
+                let status: ErrorStatus = match s {
+                    $(
+                        $error_str$( | $error_str_aliases)* => $variant,
+                    )*
+                    _ => return Err(CmdError::NotW3C(serde_json::Value::String(s.to_string()))),
+                };
+                Ok(status)
+            }
+        }
     }
+}
+
+define_error_strings! {
+    DetachedShadowRoot => "detached shadow root",
+    ElementClickIntercepted => "element click intercepted",
+    ElementNotInteractable => "element not interactable" | "element not visible",
+    ElementNotSelectable => "element not selectable",
+    InsecureCertificate => "insecure certificate",
+    InvalidArgument => "invalid argument",
+    InvalidCookieDomain => "invalid cookie domain",
+    InvalidCoordinates => "invalid coordinates" | "invalid element coordinates",
+    InvalidElementState => "invalid element state",
+    InvalidSelector => "invalid selector",
+    InvalidSessionId => "invalid session id",
+    JavascriptError => "javascript error",
+    MoveTargetOutOfBounds => "move target out of bounds",
+    NoSuchAlert => "no such alert",
+    NoSuchCookie => "no such cookie",
+    NoSuchElement => "no such element",
+    NoSuchFrame => "no such frame",
+    NoSuchShadowRoot => "no such shadow root",
+    NoSuchWindow => "no such window",
+    ScriptTimeout => "script timeout",
+    SessionNotCreated => "session not created",
+    StaleElementReference => "stale element reference",
+    Timeout => "timeout",
+    UnableToCaptureScreen => "unable to capture screen",
+    UnableToSetCookie => "unable to set cookie",
+    UnexpectedAlertOpen => "unexpected alert open",
+    UnknownCommand => "unknown command",
+    UnknownError => "unknown error",
+    UnknownMethod => "unknown method",
+    UnknownPath => "unknown path",
+    UnsupportedOperation => "unsupported operation",
 }
 
 impl TryFrom<&str> for ErrorStatus {

--- a/src/session.rs
+++ b/src/session.rs
@@ -871,10 +871,10 @@ where
                         return Err(error::CmdError::NotW3C(Json::Object(body)));
                     }
 
-                    body["error"]
-                        .as_str()
-                        .map(ErrorStatus::from)
-                        .unwrap_or(ErrorStatus::UnknownError)
+                    match body["error"].as_str() {
+                        Some(s) => s.parse()?,
+                        None => return Err(error::CmdError::NotW3C(Json::Object(body))),
+                    }
                 };
 
                 let message = match body.remove("message") {
@@ -882,7 +882,7 @@ where
                     _ => String::new(),
                 };
 
-                let mut wd_error = error::WebDriver::new(es, message);
+                let mut wd_error = error::WebDriver::new(es, message.into());
 
                 // Add the stacktrace if there is one.
                 if let Some(Json::String(x)) = body.remove("stacktrace") {

--- a/src/session.rs
+++ b/src/session.rs
@@ -882,7 +882,7 @@ where
                     _ => String::new(),
                 };
 
-                let mut wd_error = error::WebDriver::new(es, message.into());
+                let mut wd_error = error::WebDriver::new(es, message);
 
                 // Add the stacktrace if there is one.
                 if let Some(Json::String(x)) = body.remove("stacktrace") {

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -45,7 +45,7 @@
 //! condition check returns an error, the wait operation will be aborted, and the error returned.
 
 use crate::elements::Element;
-use crate::error::CmdError;
+use crate::error::{CmdError, ErrorStatus};
 use crate::wd::Locator;
 use crate::Client;
 use std::time::{Duration, Instant};
@@ -137,7 +137,7 @@ impl<'c> Wait<'c> {
         wait_on!(self, {
             match self.client.by(search.into_parameters()).await {
                 Ok(element) => Ok(Some(element)),
-                Err(CmdError::NoSuchElement(_)) => Ok(None),
+                Err(CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchElement => Ok(None),
                 Err(err) => Err(err),
             }
         })

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -5,7 +5,7 @@ use fantoccini::actions::{
     MOUSE_BUTTON_LEFT,
 };
 use fantoccini::key::Key;
-use fantoccini::{error, Client, Locator};
+use fantoccini::{error, error::ErrorStatus, Client, Locator};
 use serial_test::serial;
 use std::time::Duration;
 use time::Instant;
@@ -122,7 +122,7 @@ async fn actions_mouse_move(c: Client, port: u16) -> Result<(), error::CmdError>
     // Sanity check - ensure no alerts are displayed prior to actions.
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
 
     let actions = Actions::from(mouse_actions);

--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -5,7 +5,7 @@ use fantoccini::actions::{
     MOUSE_BUTTON_LEFT,
 };
 use fantoccini::key::Key;
-use fantoccini::{error, error::ErrorStatus, Client, Locator};
+use fantoccini::{error, Client, Locator};
 use serial_test::serial;
 use std::time::Duration;
 use time::Instant;
@@ -122,7 +122,7 @@ async fn actions_mouse_move(c: Client, port: u16) -> Result<(), error::CmdError>
     // Sanity check - ensure no alerts are displayed prior to actions.
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
 
     let actions = Actions::from(mouse_actions);

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -1,6 +1,6 @@
 //! Alert tests
 use crate::common::sample_page_url;
-use fantoccini::{error, error::ErrorStatus, Client, Locator};
+use fantoccini::{error, Client, Locator};
 use serial_test::serial;
 
 mod common;
@@ -13,7 +13,7 @@ async fn alert_accept(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
 
     c.find(Locator::Id("button-confirm")).await?.click().await?;
@@ -21,7 +21,7 @@ async fn alert_accept(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,
@@ -39,7 +39,7 @@ async fn alert_dismiss(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.dismiss_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
 
     c.find(Locator::Id("button-confirm")).await?.click().await?;
@@ -47,7 +47,7 @@ async fn alert_dismiss(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.dismiss_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,
@@ -66,7 +66,7 @@ async fn alert_text(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
+        Err(e) if e.is_no_such_alert()
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,

--- a/tests/alert.rs
+++ b/tests/alert.rs
@@ -1,6 +1,6 @@
 //! Alert tests
 use crate::common::sample_page_url;
-use fantoccini::{error, Client, Locator};
+use fantoccini::{error, error::ErrorStatus, Client, Locator};
 use serial_test::serial;
 
 mod common;
@@ -13,7 +13,7 @@ async fn alert_accept(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
 
     c.find(Locator::Id("button-confirm")).await?.click().await?;
@@ -21,7 +21,7 @@ async fn alert_accept(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,
@@ -39,7 +39,7 @@ async fn alert_dismiss(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.dismiss_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
 
     c.find(Locator::Id("button-confirm")).await?.click().await?;
@@ -47,7 +47,7 @@ async fn alert_dismiss(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.dismiss_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,
@@ -66,7 +66,7 @@ async fn alert_text(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.accept_alert().await?;
     assert!(matches!(
         c.get_alert_text().await,
-        Err(error::CmdError::NoSuchAlert(..))
+        Err(error::CmdError::Standard(w)) if w.error == ErrorStatus::NoSuchAlert
     ));
     assert_eq!(
         c.find(Locator::Id("alert-answer")).await?.text().await?,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -230,7 +230,7 @@ async fn stale_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     .await?;
 
     match elem.click().await {
-        Err(error::CmdError::NoSuchElement(_)) => Ok(()),
+        Err(error::CmdError::Standard(_)) => Ok(()),
         _ => panic!("Expected a stale element reference error"),
     }
 }
@@ -614,7 +614,11 @@ mod chrome {
     }
 
     #[test]
-    #[serial]
+    fn stale_element_test() {
+        local_tester!(stale_element, "chrome");
+    }
+
+    #[test]
     fn select_by_label_test() {
         local_tester!(select_by_label, "chrome");
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,6 +1,5 @@
 //! Tests that don't make use of external websites.
 use crate::common::{other_page_url, sample_page_url};
-use fantoccini::error::CmdError;
 use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{error, Client, Locator};
 use serial_test::serial;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,6 +1,6 @@
 //! Tests that don't make use of external websites.
 use crate::common::{other_page_url, sample_page_url};
-use fantoccini::error::{CmdError, ErrorStatus};
+use fantoccini::error::CmdError;
 use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{error, Client, Locator};
 use serial_test::serial;
@@ -231,7 +231,7 @@ async fn stale_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     .await?;
 
     match elem.click().await {
-        Err(CmdError::Standard(w)) if w.error == ErrorStatus::StaleElementReference => Ok(()),
+        Err(e) if e.is_stale_element_reference() => Ok(()),
         _ => panic!("Expected a stale element reference error"),
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,5 +1,6 @@
 //! Tests that don't make use of external websites.
 use crate::common::{other_page_url, sample_page_url};
+use fantoccini::error::{CmdError, ErrorStatus};
 use fantoccini::wd::TimeoutConfiguration;
 use fantoccini::{error, Client, Locator};
 use serial_test::serial;
@@ -230,7 +231,7 @@ async fn stale_element(c: Client, port: u16) -> Result<(), error::CmdError> {
     .await?;
 
     match elem.click().await {
-        Err(error::CmdError::Standard(_)) => Ok(()),
+        Err(CmdError::Standard(w)) if w.error == ErrorStatus::StaleElementReference => Ok(()),
         _ => panic!("Expected a stale element reference error"),
     }
 }


### PR DESCRIPTION
- Add `ErrorStatus` enum
- Remove `webdriver::error::WebDriverError`
- Use `error::WebDriver` directly to avoid double-handling

NOTE: `StaleElementReference` is no longer combined with `NoSuchElement`.

I essentially copied the `ErrorStatus` enum from the webdriver crate, noting that the majority of the comments are public documentation from the WebDriver spec. Do we need to remove the comments that are not in the spec? I'm not sure what the MPL license requirements are.

Ideally I'd like to move the `NoSuchElement` etc. variants back into the `CmdError::Standard` variant - not sure how you feel about that. That would break almost every application using this crate :( 
Otherwise there may be confusion about those variants existing in `ErrorStatus` but they can never be captured that way.

This is already a breaking change, but the changes should be pretty minimal so far.