### PR TITLE
Fix Cookie -> WebDriverCookie same_site parsing

### DIFF
--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -111,10 +111,13 @@ impl<'a> From<Cookie<'a>> for WebDriverCookie {
         let expiry = cookie
             .expires()
             .and_then(|e| e.datetime().map(|dt| dt.unix_timestamp() as u64));
-        let same_site = cookie.same_site().map(|x| match x {
-            SameSite::Strict => "Strict".to_string(),
-            SameSite::Lax => "Lax".to_string(),
-            SameSite::None => "None".to_string(),
+        let same_site = Some(match cookie.same_site() {
+            Some(x) => match x {
+                SameSite::Strict => "Strict".to_string(),
+                SameSite::Lax => "Lax".to_string(),
+                SameSite::None => "None".to_string(),
+            },
+            None => "None".to_string(),
         });
 
         Self {

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -286,6 +286,14 @@ async fn handle_cookies_test(c: Client) -> Result<(), error::CmdError> {
     c.delete_cookie(cookie.name()).await?;
     assert!(c.get_named_cookie(cookie.name()).await.is_err());
 
+    // Verify same_site None corner-case is correctly parsed
+    cookie.set_same_site(None);
+    c.add_cookie(cookie.clone()).await?;
+    assert_eq!(
+        c.get_named_cookie(cookie.name()).await?.same_site(),
+        Some(SameSite::None)
+    );
+
     c.delete_all_cookies().await?;
     let cookies = c.get_all_cookies().await?;
     assert!(dbg!(cookies).is_empty());


### PR DESCRIPTION
Fetching all cookies from fantoccini client and loading them back reveals that same_site is not properly parsed when converting from Cookie -> WebDriverCookie.

For example, client.get_all_cookies() can return both the following same_site values in different cookies, the second of which is transformed by the map call into an Option::None which gets ignored by WebDriverCookie serde skip_serializing_if = "Option::is_none":

same_site: Some(
        None,
    ),

same_site: None,

An example error when calling client.add_cookie() with the above "same_site: None":

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Standard(WebDriver { error: InvalidArgument, message: "invalid argument: invalid 'sameSite'\n
(Session info: chrome=98.0.4758.80)"

This fixes the error by parsing the top-level None value to a None string as expected by WebDriverCookie.