### PR TITLE
Fully implement the print command

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -262,7 +262,10 @@ impl WebDriverCompatibleCommand for Wcmd {
                 body = Some(serde_json::to_string(params).unwrap());
                 method = Method::POST;
             }
-
+            WebDriverCommand::Print(ref params) => {
+                body = Some(serde_json::to_string(params).unwrap());
+                method = Method::POST;
+            }
             _ => {}
         }
         (method, body)


### PR DESCRIPTION
Previously, the print command would default to using a GET, and not forwarding its parameters, but was otherwise implemented with the correct path.

I have tested that this does fix the issue, can add a test if you want as well