### PR TITLE
Slenium headless firefox bugfix

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -628,11 +628,18 @@ where
         }
 
         // make chrome comply with w3c
-        cap.entry("goog:chromeOptions".to_string())
-            .or_insert_with(|| Json::Object(serde_json::Map::new()))
-            .as_object_mut()
-            .expect("goog:chromeOptions wasn't a JSON object")
-            .insert("w3c".to_string(), Json::from(true));
+        if cap.contains_key("goog:chromeOptions") 
+            || cap.get("browserName")
+            .and_then(|v| v.as_str())
+            .filter(|s| s.to_lowercase().contains("chrom"))
+            .is_some()
+        {
+            cap.entry("goog:chromeOptions".to_string())
+                .or_insert_with(|| Json::Object(serde_json::Map::new()))
+                .as_object_mut()
+                .expect("goog:chromeOptions wasn't a JSON object")
+                .insert("w3c".to_string(), Json::from(true));
+        }
 
         let session_config = webdriver::capabilities::SpecNewSessionParameters {
             alwaysMatch: cap.clone(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -628,11 +628,12 @@ where
         }
 
         // make chrome comply with w3c
-        if cap.contains_key("goog:chromeOptions") 
-            || cap.get("browserName")
-            .and_then(|v| v.as_str())
-            .filter(|s| s.to_lowercase().contains("chrom"))
-            .is_some()
+        if cap.contains_key("goog:chromeOptions")
+            || cap
+                .get("browserName")
+                .and_then(|v| v.as_str())
+                .filter(|s| s.to_lowercase().contains("chrom"))
+                .is_some()
         {
             cap.entry("goog:chromeOptions".to_string())
                 .or_insert_with(|| Json::Object(serde_json::Map::new()))


### PR DESCRIPTION
Fixed bug where firefox ignores `moz:firefoxOptions` if `goog:chromeOptions` is defined.

Enviroment:
 - `selenium-server-4.6.0.jar` (standalone mode)  
 - `Mozilla Firefox 106.0.2`  
 - `geckodriver 0.31.0`  
 - `thirtyfour` version `0.32.0-rc.3`
 
Capabilities:
```JSON
{
  "browserName": "firefox",
  "goog:chromeOptions": {
    "w3c": true
  },
  "moz:firefoxOptions": {
    "args": [
      "-headless"
    ]
  },
  "pageLoadStrategy": "normal"
}
```
With these capabilities it should run is headless mode but it doesn't.