### PR TITLE
Update hyper-rustls to 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
@@ -612,14 +612,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -641,6 +641,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -906,13 +916,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1100,16 +1109,6 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "url",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 
 [features]
 default = ["native-tls"]
-native-tls = ["hyper-tls"]
+native-tls = ["hyper-tls", "openssl"]
 rustls-tls = ["hyper-rustls"]
 
 [dependencies]
@@ -46,7 +46,7 @@ serial_test = "2.0"
 
 # for minimal-versions
 [target.'cfg(any())'.dependencies]
-openssl = "0.10.35" # through native-tls, <.35 no longer builds
+openssl = { version = "0.10.35", optional = true } # through native-tls, <.35 no longer builds
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["sync", "rt", "time"] }
 hyper = { version = "0.14", features = ["stream", "client", "http1"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
 base64 = "0.13"
-hyper-rustls = { version = "0.23.0", optional = true }
+hyper-rustls = { version = "0.24.0", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 mime = "0.3.9"
 http = "0.2"


### PR DESCRIPTION
This PR is similar to https://github.com/jonhoo/fantoccini/pull/142 and updates `hyper-rustls` to the latest version to stay in sync with the rest of the `rustls` ecosystem.

Additionally, I made a small change to how the `openssl` dependency was being specified. As it was, it was forcing any user of the  `fantoccini` crate to depend on `openssl` even if you weren't using the `native-tls` feature.