### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/jonhoo/fantoccini.git"
 keywords = ["webdriver", "chromedriver", "geckodriver", "phantomjs", "automation"]
 categories = ["api-bindings", "development-tools::testing", "web-programming::http-client"]
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields