### PR TITLE
Move the `goog:chromeOptions` to a new URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ where
     /// in an object under a prefixed key like
     /// [`moz:firefoxOptions`](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions)
     /// or
-    /// [`goog:chromeOptions`](https://sites.google.com/a/chromium.org/chromedriver/capabilities).
+    /// [`goog:chromeOptions`](https://developer.chrome.com/docs/chromedriver/capabilities).
     ///
     /// The standard options are given below. See the
     /// [specification](https://www.w3.org/TR/webdriver1/#capabilities) for more details.


### PR DESCRIPTION
The old URL shows a generic 404 error: "Site not found".