### PR TITLE
chromedriver flags that make ci happy eveywhere

### DIFF
--- a/ci/windows-latest-chrome.ps1
+++ b/ci/windows-latest-chrome.ps1
@@ -1,6 +1,5 @@
 npm i puppeteer
-# pin to 125 due to https://issues.chromium.org/issues/42323434
-npx @puppeteer/browsers install chrome@125
-npx @puppeteer/browsers install chromedriver@125
+npx @puppeteer/browsers install chrome@stable
+npx @puppeteer/browsers install chromedriver@stable
 Start-Process -FilePath chromedriver
 Start-Sleep -Seconds 1

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -32,10 +32,7 @@ pub fn make_capabilities(s: &str) -> map::Map<String, serde_json::Value> {
                 "args": [
                     "--headless",
                     "--disable-gpu",
-                    "--no-sandbox",
                     "--disable-dev-shm-usage",
-                    // https://issues.chromium.org/issues/42323434
-                    "--remote-debugging-pipe"
                 ],
             });
             caps.insert("goog:chromeOptions".to_string(), opts);


### PR DESCRIPTION
after the stream on the July 14th I tried to dig into why windows selenium is not happy

I don't understand it really but these flags work everywhere on CI, the old flags would fail pretty much every time otherwise