### PR TITLE
README: fix Method type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ c.goto("https://www.wikipedia.org/").await?;
 let img = c.find(Locator::Css("img.central-featured-logo")).await?;
 let src = img.attr("src").await?.expect("image should have a src");
 // now build a raw HTTP client request (which also has all current cookies)
-let raw = img.client().raw_client_for(fantoccini::Method::GET, &src).await?;
+let raw = img.client().raw_client_for(http::Method::GET, &src).await?;
 
 // we then read out the image bytes
 use futures_util::TryStreamExt;


### PR DESCRIPTION
From the README I'm guessing that Method used to be re-exported by fantoccini; that's not the case in the current code. Fixed it to explicitly refer to http::Method.