### PR TITLE
fix(session): Add `UnexpectedError(CmdError)` variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum NewSessionError {
     NotW3C(serde_json::Value),
     /// The WebDriver server refused to create a new session.
     SessionNotCreated(WebDriver),
+    /// An unexpected error occurred.
+    UnexpectedError(CmdError),
 }
 
 impl Error for NewSessionError {
@@ -35,6 +37,7 @@ impl Error for NewSessionError {
             NewSessionError::Lost(..) => "webdriver server disconnected",
             NewSessionError::NotW3C(..) => "webdriver server gave non-conformant response",
             NewSessionError::SessionNotCreated(..) => "webdriver did not create session",
+            NewSessionError::UnexpectedError(..) => "unexpected webdriver error",
         }
     }
 
@@ -46,6 +49,7 @@ impl Error for NewSessionError {
             NewSessionError::Lost(ref e) => Some(e),
             NewSessionError::NotW3C(..) => None,
             NewSessionError::SessionNotCreated(ref e) => Some(e),
+            NewSessionError::UnexpectedError(ref e) => Some(e),
         }
     }
 }
@@ -61,6 +65,7 @@ impl fmt::Display for NewSessionError {
             NewSessionError::Lost(ref e) => write!(f, "{}", e),
             NewSessionError::NotW3C(ref e) => write!(f, "{:?}", e),
             NewSessionError::SessionNotCreated(ref e) => write!(f, "{}", e),
+            NewSessionError::UnexpectedError(ref e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -601,9 +601,7 @@ where
                 serde_json::to_value(e)
                     .expect("error::WebDriver should always be serializeable to JSON"),
             )),
-            Err(e) => {
-                panic!("unexpected webdriver error; {}", e);
-            }
+            Err(e) => Err(error::NewSessionError::UnexpectedError(e)),
         }
     }
 


### PR DESCRIPTION
Closes #175 

Added `UnexpectedError(CmdError)` variant to handle errors from the webdriver host that do not conform to the expected standard. 