### PR TITLE
feat: Add reconnection capability for persisted WebDriver sessions

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -68,13 +68,7 @@ impl Client {
         C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
     {
         let (client, wdb) = Session::create_client_and_parse_url(webdriver, connector).await?;
-        Session::setup_session(
-            client,
-            wdb,
-            None,
-            Some(webdriver::capabilities::Capabilities::new()),
-        )
-        .await
+        Session::setup_session(client, wdb, None).await
     }
 
     /// Reconnect to a previously established WebDriver session using its ID.
@@ -91,7 +85,7 @@ impl Client {
         C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
     {
         let (client, wdb) = Session::create_client_and_parse_url(webdriver, connector).await?;
-        Session::setup_session(client, wdb, Some(session_id), None).await
+        Session::setup_session(client, wdb, Some(session_id)).await
     }
 
     /// Connect to the WebDriver host running the given address.

--- a/src/session.rs
+++ b/src/session.rs
@@ -651,7 +651,6 @@ where
         client: hyper_util::client::legacy::Client<C, BoxBody<hyper::body::Bytes, Infallible>>,
         wdb: url::Url,
         session_id: Option<&str>,
-        _cap: Option<webdriver::capabilities::Capabilities>,
     ) -> Result<Client, error::NewSessionError> {
         // We're going to need a channel for sending requests to the WebDriver host
         let (tx, rx) = mpsc::unbounded_channel();
@@ -665,7 +664,7 @@ where
 
         // now that the session is running, let's do the handshake
         Ok(Client {
-            tx: tx.clone(),
+            tx,
             is_legacy: false,
             new_session_response: None,
         })
@@ -696,7 +695,7 @@ where
                 .insert("w3c".to_string(), Json::from(true));
         }
 
-        let mut client = Self::setup_session(client, wdb, None, Some(cap.clone())).await?;
+        let mut client = Self::setup_session(client, wdb, None).await?;
 
         let session_config = webdriver::capabilities::SpecNewSessionParameters {
             alwaysMatch: cap.clone(),
@@ -757,7 +756,6 @@ where
                     .await?;
 
                 client.is_legacy = true;
-                client.new_session_response = None;
                 Ok(client)
             }
             Err(e) => Err(e),


### PR DESCRIPTION
Closes #57   

The `with_existing_session` method introduces the ability to reconnect to an already established WebDriver session using its `session ID`. This enables reuse of an active session without having to create a new one, which is particularly beneficial in scenarios such as process restarts or unexpected disconnections.