### PR TITLE
fix(client): new_with_connector: correctly setup session

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -67,8 +67,7 @@ impl Client {
     where
         C: connect::Connect + Unpin + 'static + Clone + Send + Sync,
     {
-        let (client, wdb) = Session::create_client_and_parse_url(webdriver, connector).await?;
-        Session::setup_session(client, wdb, None).await
+        Session::with_capabilities_and_connector(webdriver, &Default::default(), connector).await
     }
 
     /// Reconnect to a previously established WebDriver session using its ID.


### PR DESCRIPTION
This change ensures that we issue a new session when we create a new client.

Close #281 
