### PR TITLE
Support querying numeric HTML properties from `elements::Element::prop()`

### DIFF
--- a/src/elements.rs
+++ b/src/elements.rs
@@ -334,7 +334,7 @@ impl Element {
     #[cfg_attr(docsrs, doc(alias = "outerHTML"))]
     pub async fn html(&self, inner: bool) -> Result<String, error::CmdError> {
         let prop = if inner { "innerHTML" } else { "outerHTML" };
-        Ok(self.prop(prop).await?.unwrap())
+        Ok(self.prop(prop).await?.unwrap().to_string())
     }
 }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -370,7 +370,13 @@ impl Element {
     #[cfg_attr(docsrs, doc(alias = "outerHTML"))]
     pub async fn html(&self, inner: bool) -> Result<String, error::CmdError> {
         let prop = if inner { "innerHTML" } else { "outerHTML" };
-        Ok(self.prop(prop).await?.unwrap().to_string())
+
+        match self.prop(prop).await? {
+            // Requesting `innerHTML` or `outerHTML` should normally return a string
+            Some(Json::String(contents)) => Ok(contents),
+            Some(res) => Err(error::CmdError::NotW3C(res)),
+            _ => Err(error::CmdError::NotW3C(Json::Null)),
+        }
     }
 }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -230,14 +230,11 @@ impl Element {
     ///
     /// [property]: https://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1
     #[cfg_attr(docsrs, doc(alias = "Get Element Property"))]
-    pub async fn prop(&self, prop: &str) -> Result<Option<String>, error::CmdError> {
+    pub async fn prop(&self, prop: &str) -> Result<Option<Json>, error::CmdError> {
         let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());
         match self.client.issue(cmd).await? {
-            Json::String(v) => Ok(Some(v)),
-            Json::Bool(b) => Ok(Some(b.to_string())),
-            Json::Number(n) => Ok(Some(n.to_string())),
             Json::Null => Ok(None),
-            v => Err(error::CmdError::NotW3C(v)),
+            v => Ok(Some(v)),
         }
     }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -223,12 +223,48 @@ impl Element {
     ///
     /// `Ok(None)` is returned if the element does not have the given property.
     ///
-    /// Boolean properties such as "checked" will be returned as the String "true" or "false".
-    ///
     /// See [13.3 Get Element Property](https://www.w3.org/TR/webdriver1/#get-element-property)
     /// of the WebDriver standard.
     ///
     /// [property]: https://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// # use fantoccini::{ClientBuilder, error, Locator};
+    /// # use serde_json::{json, Number};
+    /// # async fn no_search_results() -> Result<(), error::CmdError> {
+    /// // Define capabilities of client...
+    /// #    let capabilities = json!({})
+    /// #        .as_object()
+    /// #        .unwrap()
+    /// #        .to_owned();
+    /// #
+    /// // Create client...
+    /// # let client = ClientBuilder::native()
+    /// #   .capabilities(capabilities)
+    /// #   .connect("http://127.0.0.1:4444")
+    /// #   .await.unwrap();
+    /// #
+    /// // Perform some kind of search on the website that we don't expect any results from...
+    ///
+    /// let search_matches = client
+    ///     .wait()
+    ///     .for_element(Locator::Css("#search-matches"))
+    ///     .await?;
+    ///
+    /// let num_search_matches = search_matches
+    ///     .prop("childElementCount")
+    ///     .await?
+    ///     .expect("expected there to be some value for childElementCount property")
+    ///     .as_u64()
+    ///     .expect("expected childElementCount to be an integer value");
+    ///
+    /// assert_eq!(num_search_matches, 0);
+    /// #
+    /// #   Ok(())
+    /// # };
+    /// ```
     #[cfg_attr(docsrs, doc(alias = "Get Element Property"))]
     pub async fn prop(&self, prop: &str) -> Result<Option<Json>, error::CmdError> {
         let cmd = WebDriverCommand::GetElementProperty(self.element.clone(), prop.to_string());

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -235,6 +235,7 @@ impl Element {
         match self.client.issue(cmd).await? {
             Json::String(v) => Ok(Some(v)),
             Json::Bool(b) => Ok(Some(b.to_string())),
+            Json::Number(n) => Ok(Some(n.to_string())),
             Json::Null => Ok(None),
             v => Err(error::CmdError::NotW3C(v)),
         }

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -48,6 +48,9 @@ async fn element_prop(c: Client, port: u16) -> Result<(), error::CmdError> {
     assert_eq!(elem.prop("id").await?.unwrap(), "checkbox-option-1");
     assert_eq!(elem.prop("checked").await?.unwrap(), "false");
     assert!(elem.attr("invalid-property").await?.is_none());
+
+    let elem = c.find(Locator::Id("content")).await?;
+    assert_eq!(elem.prop("childElementCount").await?.unwrap(), "5");
     Ok(())
 }
 

--- a/tests/elements.rs
+++ b/tests/elements.rs
@@ -46,11 +46,32 @@ async fn element_prop(c: Client, port: u16) -> Result<(), error::CmdError> {
     c.goto(&sample_url).await?;
     let elem = c.find(Locator::Id("checkbox-option-1")).await?;
     assert_eq!(elem.prop("id").await?.unwrap(), "checkbox-option-1");
-    assert_eq!(elem.prop("checked").await?.unwrap(), "false");
+
+    assert_eq!(
+        elem.prop("checked")
+            .await?
+            .expect(
+                "expected checked property to exist on HTML element with ID 'checkbox-option-1'"
+            )
+            .as_bool()
+            .expect("expected checked property to be a boolean value"),
+        false,
+    );
+
     assert!(elem.attr("invalid-property").await?.is_none());
 
     let elem = c.find(Locator::Id("content")).await?;
-    assert_eq!(elem.prop("childElementCount").await?.unwrap(), "5");
+    assert_eq!(
+        elem.prop("childElementCount")
+            .await?
+            .expect(
+                "expected childElementCount property to exist on HTML element with ID 'content'"
+            )
+            .as_u64()
+            .expect("expected childElementCount property to be an integer value"),
+        5,
+    );
+
     Ok(())
 }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -529,7 +529,7 @@ async fn send_keys_and_clear_input_inner(c: Client, port: u16) -> Result<(), err
             .await?
             .expect("input should have value prop")
             .as_str(),
-        "foobar"
+        Some("foobar")
     );
 
     e.clear().await?;
@@ -538,7 +538,7 @@ async fn send_keys_and_clear_input_inner(c: Client, port: u16) -> Result<(), err
             .await?
             .expect("input should have value prop")
             .as_str(),
-        ""
+        Some("")
     );
 
     let c = e.client();


### PR DESCRIPTION
## Preface

Hi, Jon! Longtime fan of yours. Your Crust of Rust series was HUGE for me going from a beginner Rust developer to more intermediate (I've got a long way to go before the rank of "master" :smile:). Thank you for all the amazing work you do and how you give back to the community!

## Problem

I'm building [my own personal portfolio website](https://johndesilenc.io). One of the features of the application is a terminal emulator, letting you [run fake commands on the website](https://github.com/johnDeSilencio/johnDeSilencio.github.io/blob/main/src/main.rs#L60-L77).

One of the commands is `clear`, which clears the screen and the history of all previous commands. To write a functional test for this feature, I'd like to be able to tell that my `<div id="previous-commands>` has no children which I check through the [`childElementCount`](https://developer.mozilla.org/en-US/docs/Web/API/Element/childElementCount) property.

However, when I try use [`fantoccini::elements::Element::prop("childElementCount")`](https://docs.rs/fantoccini/latest/fantoccini/elements/struct.Element.html#method.prop), I get the following error:

`...webdriver returned non-conforming response: Number(0)`

![2025-03-01-162717_hyprshot](https://github.com/user-attachments/assets/1534986f-2d10-4bc0-90c1-ba191963ce56)

## Proposed Solution

It appears that the `fantoccini::elements::Element::prop` method currently only handles `String`s, `Bool`s, and `Null` values from `serde_json` and returns an error for everything else. This PR also supports matching [`serde_json::Number`](https://docs.rs/serde_json/latest/serde_json/struct.Number.html) to support getting numeric properties like `childElementCount`.

## Tests

I've also added another `assert_eq!()` to the `element_test` function. Let me know if you'd like me to add more test coverage or to find another way to support numeric HTML properties.

## Functional Tests

I used this fork in the E2E tests for my website and now my functional tests pass:

![image](https://github.com/user-attachments/assets/002bbed4-e1af-492a-940d-3d9003abdb94)