### PR TITLE
printsize (fix): swap const width and height for A4

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -217,8 +217,8 @@ pub struct PrintSize {
 impl PrintSize {
     /// The standard A4 paper size, which has the dimension of `21.0x29.7cm`.
     pub const A4: Self = Self {
-        width: 29.7,
-        height: 21.0,
+        width: 21.0,
+        height: 29.7,
     };
 
     /// The standard US letter paper size, which has the dimension of `21.59x27.94cm`.

--- a/src/print.rs
+++ b/src/print.rs
@@ -217,7 +217,7 @@ pub struct PrintSize {
 impl PrintSize {
     /// The standard A4 paper size, which has the dimension of `21.0x29.7cm`.
     pub const A4: Self = Self {
-        width: 21.0,
+        width: 21.,
         height: 29.7,
     };
 


### PR DESCRIPTION
This fixes the A4 paper size const definition in the printsize struct, where the width and height values were inverted